### PR TITLE
Bugfix/fix infinity scroll in ballot list page

### DIFF
--- a/src/pages/trails/ballots/list/ballots-list.vue
+++ b/src/pages/trails/ballots/list/ballots-list.vue
@@ -31,7 +31,8 @@ export default {
       page: 1,
       sortMode: "",
       startY: 0,
-      timerAction: null
+      timerAction: null,
+      limit: 50,
     };
   },
   props: {
@@ -56,11 +57,11 @@ export default {
     this.$refs.infiniteScroll.reset();
     this.$refs.infiniteScroll.poll();
   },
-  created () {
-    window.addEventListener('scroll', this.onLoad);
+  created() {
+    window.addEventListener("scroll", this.onLoad);
   },
-  unmounted () {
-    window.removeEventListener('scroll', this.onLoad);
+  unmounted() {
+    window.removeEventListener("scroll", this.onLoad);
   },
 
   methods: {
@@ -73,32 +74,32 @@ export default {
     ]),
     ...mapMutations("trails", ["resetBallots", "stopAddBallots"]),
 
-    async onLoad(status, done) {
-      let limit = 30
-      let scrollY = window.scrollY
-      this.$refs.infiniteScroll.resume();
-      clearTimeout(this.checkTimer)
-      if ((scrollY > this.startY && scrollY % 250) || status === true) {
-        limit+= 30
+    async onLoad(status) {
+      let scrollY = window.scrollY;
+      if (
+        (scrollY > this.startY && this.limit !== 500) ||
+        status === true
+      ) {
+        this.$refs.infiniteScroll.resume();
+        this.limit += 25;
         const filter = {
           index: 4,
           lower:
             this.treasury || (this.$route.query && this.$route.query.treasury),
           upper:
             this.treasury || (this.$route.query && this.$route.query.treasury),
-          limit: limit <= 300 ? limit : 300,
+          limit: this.limit,
         };
-        this.checkTimer = setTimeout (async () => {
-          await this.fetchBallots(filter)
-          if (scrollY === this.startY) {
-            this.$refs.infiniteScroll.stop()
-          }
-        }, 3000)
+        await this.fetchBallots(filter);
+        if (scrollY === this.startY) {
+          this.$refs.infiniteScroll.stop();
+        }
+      } else {
+        setTimeout(() => {
+          this.$refs.infiniteScroll.stop();
+        }, 3000);
       }
-      this.startY = scrollY
-      this.checkTimer = setTimeout (() => {
-        this.$refs.infiniteScroll.stop()
-      }, 3000)
+      this.startY = scrollY;
     },
     openBallotForm() {
       this.show = true;
@@ -159,15 +160,18 @@ export default {
       return localStorage.isNewUser;
     },
     updateTreasury(newTreasury) {
-      this.onLoad(true)
+      this.limit = 0;
+      this.onLoad(true);
       this.treasury = newTreasury;
     },
     updateStatuses(newStatuses) {
-      this.onLoad(true)
+      this.limit = 0;
+      this.onLoad(true);
       this.statuses = newStatuses;
     },
     updateCategories(newCategories) {
-      this.onLoad(true)
+      this.limit = 0;
+      this.onLoad(true);
       this.categories = newCategories;
     },
     filterBallots(ballots) {
@@ -207,7 +211,8 @@ export default {
       );
     },
     changeDirection(isBallotListRowDirection) {
-      this.onLoad(true)
+      this.limit = 0;
+      this.onLoad(true);
       this.isBallotListRowDirection = isBallotListRowDirection;
     },
     getLoser() {
@@ -238,7 +243,8 @@ export default {
     },
 
     changeSortOption(option) {
-      this.onLoad(true)
+      this.limit = 0;
+      this.onLoad(true);
       this.sortMode = option;
     },
     ballotContentImg(ballot) {
@@ -288,7 +294,6 @@ q-page
   .ballots(ref="ballotsRef")
     q-infinite-scroll(
       ref="infiniteScroll"
-      @load="onLoad"
       :offset="250"
     )
       div(:class="isBallotListRowDirection ? 'row-direction' : 'column-direction'")


### PR DESCRIPTION
# Description

Fixes #10 
We need to keep track of the last result from the api when getting all ballots so we can get the next items

## Changes

List the changes made to achieve the feature or fix the bug.

-   Rewritten function
-   add some condicitons for check state position

## Screenshots

<img width="831" alt="Снимок экрана 2022-09-01 в 23 28 26" src="https://user-images.githubusercontent.com/92740446/188016317-44409616-02b9-4c27-9a0a-b930e98a6be7.png">


# How Has This Been Tested?

scroll the window

# Checklist:

-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings
-   [x] I have executed manual tests that prove my fix is effective or that my feature works
