### PR TITLE
fix treasury-list for user

### DIFF
--- a/src/pages/trails/ballots/components/ballot-form.vue
+++ b/src/pages/trails/ballots/components/ballot-form.vue
@@ -179,6 +179,8 @@ export default {
   },
   mounted() {
     this.fetchFees();
+
+    this.fetchTreasuriesForUser(this.account);
   },
 };
 </script>
@@ -196,7 +198,7 @@ q-dialog(
 
     q-card-section.bg-primary.text-white
       .text-h6 Create a ballot
-    
+
     q-card-section
       q-input(
         ref="title"


### PR DESCRIPTION
# Description

Fixes #48 
When creating a new poll, the treasury that my account is registered to does not appear on the list.

## Changes

Add init-call for treasuries

## Screenshots

<img width="676" alt="Снимок экрана 2022-09-09 в 17 15 51" src="https://user-images.githubusercontent.com/92740446/189384241-a3507511-3bb4-47d7-a6ff-b28882cec2a9.png">

# How Has This Been Tested?

-Make sure you're registered in at least one group
-Go to the ballots page
-Click on create new ballot
-Click on treasury
-See that no treasury is listed

# Checklist:

-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings
-   [x] I have executed manual tests that prove my fix is effective or that my feature works
