### PR TITLE
Bugfix/fix height container info

### DIFF
--- a/src/pages/trails/ballots/view/BallotView.vue
+++ b/src/pages/trails/ballots/view/BallotView.vue
@@ -241,7 +241,7 @@ export default {
                         div(@click="showDetails = false")
                             img.poll-icon(src="statics/app-icons/back.svg")
                             span Go Back
-                    q-card-section
+                    q-card-section.body-info
                         div(v-for="option in getVariants")
                             div.text-weight-bold.variant-name {{ option.key }}
                             div.list-voters(v-for="(i, idx) in getVoters(option.key)" :key="idx")
@@ -489,6 +489,11 @@ export default {
             q-spinner(size="3em")
 </template>
 <style lang="sass">
+.body-info
+   overflow: scroll
+   overflow-x: hidden
+   height: 550px
+
 .variant-name
     margin-top: 24px
     margin-bottom: 8px
@@ -856,4 +861,5 @@ embed
     @media (max-width: 400px)
         .custom-caption > .caption-text
             max-width: 150px
+
 </style>


### PR DESCRIPTION
# Description

Fixes #69
Expanding the account list is cut off (can't scroll through list)


## Changes

List the changes made to achieve the feature or fix the bug.

-   Add overflow
-   Change height

## Screenshots

<img width="321" alt="Снимок экрана 2022-09-17 в 15 51 51" src="https://user-images.githubusercontent.com/92740446/190860489-001e4932-5acb-4f77-9670-bcc576079a06.png">

# How Has This Been Tested?

Steps to reproduce the behavior:

Go to proposal
Click on '>' to the right of 'number of accounts' to expand list
Scroll container with info

# Checklist:

-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings
-   [x] I have executed manual tests that prove my fix is effective or that my feature works
