### PR TITLE
now user balance is allways updated in ballots page

### DIFF
--- a/src/pages/trails/ballots/components/BallotForm.vue
+++ b/src/pages/trails/ballots/components/BallotForm.vue
@@ -92,6 +92,9 @@ export default {
         return null;
       }
     },
+    fee() {
+      return this.ballotFees ? this.ballotFees.value : 0;
+    },
   },
   methods: {
     ...mapActions("trails", [
@@ -160,6 +163,11 @@ export default {
       const ipfs = await IPFS.create();
       this.cid = await ipfs.add(file);
     },
+    async updateUserBalance() {
+      const getAccount = await this.$store.$api.getAccount(this.account);
+      this.userBalance = this.onlyNumbers(getAccount.core_liquid_balance);
+      console.log("updateUserBalance() ---> ", this.userBalance);
+    },
   },
   watch: {
     file: function () {
@@ -167,9 +175,7 @@ export default {
     },
     account: async function (account) {
       this.fetchTreasuriesForUser(account);
-      const getAccount = await this.$store.$api.getAccount(this.account);
-      this.userBalance = this.onlyNumbers(getAccount.core_liquid_balance);
-      this.fee = this.ballotFees.value;
+      this.updateUserBalance();
     },
     cid: function () {
       this.form.IPFSString = this.cid.path;
@@ -177,7 +183,7 @@ export default {
   },
   mounted() {
     this.fetchFees();
-
+    this.updateUserBalance();
     this.fetchTreasuriesForUser(this.account);
   },
 };

--- a/src/pages/trails/ballots/components/BallotForm.vue
+++ b/src/pages/trails/ballots/components/BallotForm.vue
@@ -166,7 +166,6 @@ export default {
     async updateUserBalance() {
       const getAccount = await this.$store.$api.getAccount(this.account);
       this.userBalance = this.onlyNumbers(getAccount.core_liquid_balance);
-      console.log("updateUserBalance() ---> ", this.userBalance);
     },
   },
   watch: {


### PR DESCRIPTION
# Description
The ballot page didn't have updated the user's balance and that was causing the ballot creation to fail due to an incorrect "lack of funds" error. Now the balance is always updated so this bug is fixed.

Fixes and closes #114
