### PR TITLE
Fixing a bug related to cleos login

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@quasar/extras": "^1.0.0",
-    "@telosnetwork/ual-cleos": "^0.1.0",
+    "@telosnetwork/ual-cleos": "1.12.0",
     "assert": "^2.0.0",
     "axios": "^0.21.1",
     "core-js": "^3.6.5",

--- a/src/store/accounts/actions.js
+++ b/src/store/accounts/actions.js
@@ -86,6 +86,7 @@ export const logout = async function ({ commit }) {
   commit("setAccount");
 
   localStorage.removeItem("account");
+  localStorage.removeItem("autoLogin");
   if (this.$router.path !== "/") {
     this.$router.push({ path: "/" });
   }


### PR DESCRIPTION
# Description
Without this fix, it was happening that if you log in with cleos, then log out and log in again, it never asked for the account name and permission. Instead, it goes directly to logged state with `null` as the account name.

Fixes #176