### PR TITLE
adding green-chip to voted ballots

### DIFF
--- a/src/css/quasar.variables.sass
+++ b/src/css/quasar.variables.sass
@@ -47,11 +47,12 @@ $referendum-color:              #F5898A
 $proposal-color:                #FA7238
 $election-color:                #71DA76
 $leaderboard-color:             #8A8EF5
+$ended-color:                   #F7F7F7
 
 @include new_color(voted,       $voted-color)
 @include new_color(poll,        $poll-color)
 @include new_color(referendum,  $referendum-color)
 @include new_color(proposal,    $proposal-color)
 @include new_color(election,    $election-color)
-@include new_color(leaderboard, $leaderboard-color)
+@include new_color(ended,       $ended-color)
 

--- a/src/pages/trails/ballots/components/BallotChip.vue
+++ b/src/pages/trails/ballots/components/BallotChip.vue
@@ -16,7 +16,7 @@ export default {
 </script>
 
 <template lang="pug">
-q-chip(square text-color="white" :color="`${type}`").capitalize.no-margin.text-weight-bold.ballot-type
+q-chip(square text-color="white" :color="isBallotOpened ? `${type}` : 'ended'").capitalize.no-margin.text-weight-bold.ballot-type
   q-avatar
     template(v-if="isBallotOpened")
       img(:src="`statics/app-icons/${type.toLowerCase()}-icon.svg`").poll-icon

--- a/src/pages/trails/ballots/components/BallotListItem.vue
+++ b/src/pages/trails/ballots/components/BallotListItem.vue
@@ -100,7 +100,9 @@ div
         template(v-else)
           img(:src="`statics/app-icons/inactive-bgr-icon1.png`").bgr-icon1
           img(:src="`statics/app-icons/inactive-bgr-icon2.png`").bgr-icon2
-    ballot-chip(:type="ballot.category", :isBallotOpened="isBallotOpened").absolute-top-left
+    div.column.items-start.absolute-top-left
+      ballot-chip(:type="ballot.category", :isBallotOpened="isBallotOpened")
+      ballot-chip(:type="'voted'", :isBallotOpened="isBallotOpened", :class="userVotes[ballot.ballot_name] ? '' : 'hidden'")
 
     q-separator.card-separator-vertical(vertical inset)
 
@@ -113,7 +115,6 @@ div
     )
 
     q-card-section().q-pb-none.cursor-pointer.title-section
-      span.voted__text.voted__text--absolute.absolute-top-right.q-mt-md.q-mr-md(:class="userVotes[ballot.ballot_name] ? '' : 'hidden'") Voted!
       div.text-section.row.ballot-card-title-wrapper
         span.ballot-card-title {{ ballot.title || "Untitled Ballot" }}
       div.ballot-card-sub-title-wrapper.row
@@ -175,8 +176,6 @@ div
           span.text-weight-bold {{ ballot.total_raw_weight.split(' ')[0].split('.')[0] }}&nbsp
           span.opacity06 {{ ballot.total_raw_weight.split(' ')[1]  }}&nbsp
           span.opacity06 tokens
-        div.statics-section-item.voted(:class="userVotes[ballot.ballot_name] ? '' : 'hidden'")
-          span.voted__text Voted!
 
     q-card-section().column.q-ma-lg.justify-end.btn-section
       q-btn(


### PR DESCRIPTION
# Description
Making all voted ballots to be visually consistent. 

Fixes #163
The current orange sign was not consistent with the green chip shown when the ballot is open. 

## Changes
- Removing the big orange "Voted!"
- Adding a simple top-left green chip
- Adding a new color "ended" `#F7F7F7`

## Screenshots
![image](https://user-images.githubusercontent.com/4420760/195460462-9ecb62a7-cff7-4377-8da1-e8dea2478ceb.png)
