### PR TITLE
CleosAuthenticator autologin definitive patch

### DIFF
--- a/src/boot/ual.js
+++ b/src/boot/ual.js
@@ -19,10 +19,23 @@ export default boot(async ({ app, store }) => {
     ],
   };
 
+  const getAuthenticator = function (ual, wallet = null) {
+    wallet = wallet || localStorage.getItem("autoLogin");
+    const idx = ual.authenticators.findIndex(
+      (auth) => auth.constructor.name === wallet
+    );
+    return {
+      authenticator: ual.authenticators[idx],
+      idx,
+    };
+  };
+
   async function loginHandler() {
     let accountName = "eosio";
     let permission = "active";
-    if (localStorage.getItem("autoLogin") === "CleosAuthenticator") {
+    
+    const { authenticator } = getAuthenticator(ual);
+    if (authenticator instanceof CleosAuthenticator) {
       accountName = localStorage.getItem("account");
     } else {
       await new Promise((resolve) => {

--- a/src/boot/ual.js
+++ b/src/boot/ual.js
@@ -19,23 +19,10 @@ export default boot(async ({ app, store }) => {
     ],
   };
 
-  const getAuthenticator = function (ual, wallet = null) {
-    wallet = wallet || localStorage.getItem("autoLogin");
-    const idx = ual.authenticators.findIndex(
-      (auth) => auth.constructor.name === wallet
-    );
-    return {
-      authenticator: ual.authenticators[idx],
-      idx,
-    };
-  };
-
   async function loginHandler() {
     let accountName = "eosio";
     let permission = "active";
-    
-    const { authenticator } = getAuthenticator(ual);
-    if (authenticator instanceof CleosAuthenticator) {
+    if (localStorage.getItem("autoLogin") === "cleos") {
       accountName = localStorage.getItem("account");
     } else {
       await new Promise((resolve) => {

--- a/src/store/accounts/actions.js
+++ b/src/store/accounts/actions.js
@@ -3,7 +3,7 @@
 const getAuthenticator = function (ual, wallet = null) {
   wallet = wallet || localStorage.getItem("autoLogin");
   const idx = ual.authenticators.findIndex(
-    (auth) => auth.constructor.name === wallet
+    (auth) => auth.getName() === wallet
   );
   return {
     authenticator: ual.authenticators[idx],
@@ -38,7 +38,7 @@ export const login = async function (
       const defaultReturnUrl = localStorage.getItem("returning")
         ? "/"
         : `/profiles/display/${accountName}`;
-      localStorage.setItem("autoLogin", authenticator.constructor.name);
+      localStorage.setItem("autoLogin", authenticator.getName());
       localStorage.setItem("account", accountName);
       localStorage.setItem("returning", true);
       this.$router.push({ path: returnUrl || defaultReturnUrl });


### PR DESCRIPTION
# Fixes #177

## Description
The previous solution works only in local (non-compressed code) deploys. The problem was that a decision was taken based only on the name of the authenticator constructor. This name (like most of the names) is replaced by a single-letter name and that breaks the solution based on names.

The new solution instead of asking for the authenticator's name, asks if the current authenticator is an instance of CleosAuthenticator class. So this solution should work also when deployed with compressed code.

