### PR TITLE
fixed missing (first) argument of a store.action function

### DIFF
--- a/src/store/accounts/actions.js
+++ b/src/store/accounts/actions.js
@@ -156,7 +156,7 @@ export const verifyOTP = async function (
 };
 
 export const createAccount = async function (
-
+  VueObject,
   { account, recaptchaResponse, publicKey }
 ) {
   try {


### PR DESCRIPTION
# Fixes #199 

## Description
Somehow the first argument of the store-action function "createAccount" was missing and therefore the passed arguments get lost. That was causing the POST body to be empty.
