### PR TITLE
display new metadata for ballots and support for the non-opened state

### DIFF
--- a/src/components/ActionBar.vue
+++ b/src/components/ActionBar.vue
@@ -906,12 +906,10 @@ div.bar-filter-wrapper
         q-card-actions(align="right" class="bg-white")
           q-btn(flat label="OK" v-close-popup)
 </template>
-<style lang="sass">
+<style lang="sass" scoped>
 .scroll-anim
   margin-top: 10px !important
   margin-bottom: 10px !important
-main.q-page
-  padding-top: 40px
 .bar-filter-wrapper
   margin: 0 0 8px 0
 .bar-wrapper

--- a/src/components/ActionBar.vue
+++ b/src/components/ActionBar.vue
@@ -654,7 +654,7 @@ div.bar-filter-wrapper
           q-icon.bar-btn-toggle(name="fas fa-bars")
       div.bar-custom-separator
       div.bar-filters
-        div.row.bar-filter-btns-wrapper
+        div.row
           //- 'Sort by' button
           q-btn.q-mr-md(
             v-if="!sortMode"
@@ -879,7 +879,7 @@ div.bar-filter-wrapper
               color="primary"
               outline
             )
-      q-btn.bar-filter-btn-320(
+      q-btn.bar-filter-btn-320.q-mx-md(
         :label="$t('pages.trails.ballots.actionBar.filterTitle')"
         icon-right="filter_list"
         @click="handleFilterBtnClick()"
@@ -888,16 +888,15 @@ div.bar-filter-wrapper
         outline
       )
       div.separator-320
-      div.right-bar-section.col-grow.row.items-center.justify-end.hidden
-        q-separator.bar-separator-vertical(vertical inset)
-        btn.create-poll-btn(
-          :labelText="$t('pages.trails.ballots.actionBar.btnCreatePoll')"
-          iconRight
-          padding='0'
-          primary
-          btnWidth='155'
-          fontSize='16'
-          @clickBtn="isAuthenticated ? openBallotForm() : openNotice()"
+      div.right-bar-section.col-grow.row.items-center.justify-end
+        q-separator.bar-separator-vertical.q-mr-md(vertical inset)
+        q-btn.q-mx-md(
+          :label="$t('pages.trails.ballots.actionBar.btnCreatePoll')"
+          icon-right="add"
+          color="primary"
+          no-caps
+          outline
+          @click="isAuthenticated ? openBallotForm() : openNotice()"
         )
     q-dialog(v-model="notice")
       q-card.notice
@@ -909,11 +908,8 @@ div.bar-filter-wrapper
 </template>
 <style lang="sass">
 .scroll-anim
-  height: 0px !important
   margin-top: 10px !important
   margin-bottom: 10px !important
-  pointer-events: none
-  opacity: 0
 main.q-page
   padding-top: 40px
 .bar-filter-wrapper
@@ -939,9 +935,7 @@ main.q-page
   border-radius: 2px
   margin: 0 26px
 .bar-separator-vertical
-  margin: 2px 0 2px 20px
-  height: 84px
-  margin-right: 32px
+  height: 68px
 .separator-320
   margin: 2px 20px
   display: none
@@ -970,7 +964,6 @@ main.q-page
     border: none
 .bar-filter-btn-320
   display: none
-  margin-left: 12px
 .q-btn__wrapper
   padding: 4px 12px
 .bar-filter-menu-320
@@ -1042,8 +1035,6 @@ main.q-page
   .bar-btns-toggle,
   .bar-custom-separator
     display: none !important
-  .bar-filter-btns-wrapper
-    margin-left: 16px
 @media (max-width: 1130px)
   .bar-linear-gradient-left,
   .bar-linear-gradient-right
@@ -1051,9 +1042,7 @@ main.q-page
   .bar-wrapper
     height: 72px
   .bar-separator-vertical
-    height: 60px
-  .bar-filter-btns-wrapper
-    min-width: 690px
+    height: 56px
   .bar-filters
     max-width: 73%
     overflow-x: scroll

--- a/src/css/app.sass
+++ b/src/css/app.sass
@@ -27,6 +27,8 @@ body
   a:-webkit-any-link 
     text-decoration: none
 
+.flex-grow
+  flex-grow: 1
 @media (min-width: 0)
   .q-pb-xs-sm
     padding-bottom: 8px

--- a/src/css/quasar.variables.sass
+++ b/src/css/quasar.variables.sass
@@ -56,3 +56,64 @@ $ended-color:                   #F7F7F7
 @include new_color(election,    $election-color)
 @include new_color(ended,       $ended-color)
 
+// --------------------------------------
+
+@import '~quasar/src/css/variables'
+
+$container-padding: 20px
+
+div.container,
+div.container-sm,
+div.container-md,
+div.container-lg,
+div.container-xl 
+  width: 100%
+  margin-right: auto
+  margin-left: auto
+  max-width: none
+
+@media (min-width: $breakpoint-sm-min) 
+  div.container,
+  div.container-sm 
+    max-width: $breakpoint-xs - $container-padding
+
+@media (min-width: $breakpoint-md-min) 
+  div.container,
+  div.container-sm,
+  div.container-md 
+    max-width: $breakpoint-sm - $container-padding
+
+@media (min-width: $breakpoint-lg-min) 
+  div.container,
+  div.container-sm,
+  div.container-md,
+  div.container-lg 
+    max-width: $breakpoint-md - $container-padding
+
+@media (min-width: $breakpoint-xl-min) 
+  div.container,
+  div.container-sm,
+  div.container-md,
+  div.container-lg,
+  div.container-xl 
+    max-width: $breakpoint-lg - $container-padding
+    
+// --------------------------------------
+
+$container-padding: 20px
+
+.gap
+  gap: 25px
+.gap-xs
+  gap: 4px
+.gap-sm
+  gap: 8px
+.gap-md
+  gap: 15px
+.gap-lg
+  gap: 20px
+.gap-xl
+  gap: 25px
+.gap-xxl
+  gap: 40px
+  

--- a/src/i18n/en-us/index.js
+++ b/src/i18n/en-us/index.js
@@ -31,11 +31,16 @@ export default {
       copyKey: 'Copy the key to a safe place',
       dateFuture: 'The date must be in the future',
       greaterOrEqualThan:
-        'The value must be greater than than or equal to {value}',
+        'The value must be greater than or equal to {value}',
+      lowerOrEqualThan:
+        'The value must be lower than or equal to {value}',
       integer: 'Please type an integer',
+      natural: 'Please type a natural number (>=0)',
       phoneFormat: 'Please type a valid phone',
       positiveInteger: 'The value must be greater than 0',
       required: 'This field is required',
+      atLeast: 'You need at least {what}',
+      unique: 'Repeated values are not allowed',
       token: 'The field must contain between 2 and 6 characters',
       tokenDecimals: 'The decimals must be between 2 and 9',
     },

--- a/src/i18n/en-us/index.js
+++ b/src/i18n/en-us/index.js
@@ -151,6 +151,9 @@ export default {
         starts: 'Starts',
         delete: 'Delete',
         requestAmount: 'request amount',
+        openBallotHeader: 'Open this ballot for voting',
+        openBallot: 'Open for voting',
+        notOpened: 'not open yet',
         welcomeCard: {
           title: 'Hi, ',
           textBeginning: 'Welcome to the ',

--- a/src/mixins/validation.js
+++ b/src/mixins/validation.js
@@ -2,45 +2,86 @@ import { mapActions } from 'vuex';
 const regex = new RegExp(/Qm[1-9A-HJ-NP-Za-km-z]{44}(\/.*)?/, 'm'); // ipfs hash detection, detects CIDv0 46 character strings starting with 'Qm'
 
 export const validation = {
-  data() {
+  data () {
+    let off = false;
     return {
       rules: {
-        accountExists: async (account) =>
+        setActive: active => off = !active,
+        isActive: () => !off,
+        accountExists: async account =>
+          off ||
           !(await this.isAccountFree(account.toLowerCase())) ||
           this.$t('forms.errors.accountNotExists', { account }),
-        accountFormat: (val) =>
+        accountFormat: val =>
+          off ||
           /^([a-z]|[1-5]|.){1,12}$/.test(val.toLowerCase()) ||
           this.$t('forms.errors.accountFormat'),
-        accountFormatBasic: (val) =>
+        accountFormatBasic: val =>
+          off ||
           /^([a-z]|[1-5]){12}$/.test(val.toLowerCase()) ||
           this.$t('forms.errors.accountFormatBasic'),
-        accountLength: (val) =>
-          val.length <= 12 || this.$t('forms.errors.accountLength'),
-        dateFuture: (date) => (val) =>
+        accountLength: val =>
+          off ||
+          val.length <= 12 ||
+          this.$t('forms.errors.accountLength'),
+        dateFuture: date =>
+          val =>
+          off ||
           new Date(val).getTime() >= new Date(date).getTime() ||
           this.$t('forms.errors.dateFuture'),
-        greaterOrEqualThan: (value) => (val) =>
-          val >= value || this.$t('forms.errors.greaterOrEqualThan', { value }),
-        minimumOptions: (value) => (val) =>
+        greaterOrEqualThan: value =>
+          val =>
+          off ||
+          val >= value ||
+          this.$t('forms.errors.greaterOrEqualThan', { value }),
+        lowerOrEqualThan: value =>
+          val =>
+          off ||
+          val <= value ||
+          this.$t('forms.errors.lowerOrEqualThan', { value }),
+        minimumOptions: value =>
+          val =>
+          off ||
           val.length >= value ||
           this.$t('forms.errors.greaterOrEqualThan', { value }),
-        isAccountAvailable: async (account) =>
+        isAccountAvailable: async account =>
+          off ||
           (await this.isAccountFree(account.toLowerCase())) ||
           this.$t('forms.errors.accountNotAvailable', { account }),
-        isInteger: (val) =>
-          Number.isInteger(parseInt(val)) || this.$t('forms.errors.integer'),
-        isToken: (val) =>
-          (val.length >= 2 && val.length <= 6) || this.$t('forms.errors.token'),
-        isTokenDecimals: (val) =>
+        isInteger: val =>
+          off ||
+          Number.isInteger(parseInt(val)) ||
+          this.$t('forms.errors.integer'),
+        isNatural: val =>
+          off ||
+          Number.isInteger(parseInt(val)) && parseInt(val)>=0 ||
+          this.$t('forms.errors.natural'),
+        isToken: val =>
+          off ||
+          (val.length >= 2 && val.length <= 6) ||
+          this.$t('forms.errors.token'),
+        isTokenDecimals: val =>
+          off ||
           (parseInt(val) >= 0 && parseInt(val) <= 9) ||
           this.$t('forms.errors.tokenDecimals'),
-        positiveInteger: (val) =>
-          parseInt(val) > 0 || this.$t('forms.errors.positiveInteger'),
-        isValidIPFShash: (val) =>
-          val.match(regex) || 'Invalid IPFS HASH format',
-        required: (val) => !!val || this.$t('forms.errors.required'),
-      },
-    };
+        positiveInteger: val =>
+          off ||
+          parseInt(val) > 0 ||
+          this.$t('forms.errors.positiveInteger'),
+        isValidIPFShash: val =>
+          off ||
+          val.match(regex) ||
+          'Invalid IPFS HASH format',
+        arrayWithUniqueItems: arr =>
+          off ||
+          arr.length == new Set(arr).size ||
+          this.$t('forms.errors.unique'),
+        required: val =>
+          off ||
+          !!val ||
+          this.$t('forms.errors.required'),
+      }
+    }
   },
   methods: {
     ...mapActions('accounts', ['isAccountFree']),

--- a/src/pages/trails/ballots/components/BallotForm.vue
+++ b/src/pages/trails/ballots/components/BallotForm.vue
@@ -31,8 +31,8 @@ export default {
       ballotTypes: [TYPE_OF_BALLOT_0, TYPE_OF_BALLOT_1, TYPE_OF_BALLOT_2],
       isBallotListRowDirection: true,
       openForVoting: true,
+      onlyOneOption: true,
       form: {
-        onlyOneOption: true,
         newOptionLabel: '',
         newOptionValue: '',
         defaultLabels:['Yes', 'No', 'Abstain'],
@@ -317,14 +317,6 @@ export default {
     getEndTime(ballot) {
       if (!ballot) return new Date();
       return new Date();
-    },
-    ballotContentImg(ballot) {
-      // TODO: refactor needed. This function is copied from BallotsList.vue
-      try {
-        return JSON.parse(ballot.content).imageUrl;
-      } catch (error) {
-        return null;
-      }
     },
     async onAddBallot() {
       this.submitting = true;
@@ -785,7 +777,6 @@ q-dialog(
                 :getStartTime="getStartTime()"
                 :getEndTime="form.endDate"
                 :getLoser="getLoser"
-                :ballotContentImg="ballotContentImg"
               )
             .col.flex.column.preview-right
               .q-mt-sm

--- a/src/pages/trails/ballots/components/BallotForm.vue
+++ b/src/pages/trails/ballots/components/BallotForm.vue
@@ -90,8 +90,7 @@ export default {
       )} ${supplyToSymbol(zero_supply)}`
       return {
         treasury: this.treasury,
-        description:
-          this.form.IPFSString && this.form.IPFSString.trim() !== ''
+        description: this.form.IPFSString && this.form.IPFSString.trim() !== ''
             ? `${this.form.description} ${this.form.IPFSString}`
             : this.form.description,
         content: this.createContentField(),
@@ -248,7 +247,11 @@ export default {
         final.contentUrls = [this.form.IPFSString];
       }
 
-      return JSON.stringify(final);
+      let final_str = JSON.stringify(final);
+      console.log("final: ", [final]);
+      console.log("final_str: ", [final_str]);
+
+      return final_str;
     },
     treasuryToOption(treasury) {
       if (!treasury) return null;
@@ -364,10 +367,16 @@ export default {
         config: 'votestake',
         file: null
       };
-      this.step = 1;
-      this.setOfficialDAO();
-      this.cid = null;
       this.rules.setActive(false);
+      this.step = 1;
+      this.typeOfBallot = this.ballotTypes[0];
+      this.isOfficial = true;
+      this.onlyOneOption = true;
+      this.openForVoting = true;
+      this.badImage = false;
+      this.cid = null;
+      this.setOfficialDAO();
+     
     },
     onCancel() {
       this.$emit('close');
@@ -398,6 +407,9 @@ export default {
       try {
         const ipfs = await IPFS.create();
         this.cid = await ipfs.add(file);
+
+        console.log("convertToIPFS() this.cid.path: ", this.cid.path);
+        console.log("convertToIPFS() this.form.IPFSString: ", this.form.IPFSString);
       } catch (e) {
         if (e.code == 'ERR_LOCK_EXISTS') return;
         console.error(e);
@@ -469,6 +481,8 @@ export default {
         this.fetchFees();
         this.updateUserBalance();
         this.fetchTreasuriesForUser(this.account);
+      } else {
+        this.resetBallot();
       }
     },
     badImage() {
@@ -709,7 +723,7 @@ q-dialog(
                   .flex.row.justify-end.gap-sm
                     q-checkbox(v-model="onlyOneOption" v-if="onlyOneOption") Voters can only choose one option
                     div.flex-grow
-                    q-btn(no-caps color="primary" icon="list" label="Reset" @click="setDefaultOptions(3)")
+                    q-btn(no-caps color="primary" icon="list" label="Default" @click="setDefaultOptions(3)")
                     q-btn(no-caps color="primary" icon="delete_sweep" label="Clean" @click="cleanOptions()")
                 .col.flex.column.options-right(v-if="!onlyOneOption")
                   q-checkbox(v-model="onlyOneOption") Voters can only choose one option

--- a/src/pages/trails/ballots/components/BallotForm.vue
+++ b/src/pages/trails/ballots/components/BallotForm.vue
@@ -422,7 +422,7 @@ export default {
   },
   watch: {
     'form.file': function () {
-      this.convertToIPFS(this.file);
+      this.convertToIPFS(this.form.file);
     },
     account: async function (account) {
       this.fetchTreasuriesForUser(account);

--- a/src/pages/trails/ballots/components/BallotForm.vue
+++ b/src/pages/trails/ballots/components/BallotForm.vue
@@ -4,8 +4,7 @@ import { validation } from '~/mixins/validation';
 import * as IPFS from 'ipfs-core';
 import BallotListItem from '~/pages/trails/ballots/components/BallotListItem';
 import moment from 'moment';
-import { ref } from 'vue'
-import slugify from 'slugify';
+import { ref } from 'vue';
 import { supplyToDecimals, supplyToSymbol } from '~/utils/assets';
 
 
@@ -76,7 +75,6 @@ export default {
     ...mapGetters('trails', ['treasuries', 'userTreasury', 'ballotFees']),
     ...mapGetters('accounts', ['account','accountData']),
     optionsAsText() {
-      console.log('computed optionsAsText() ->', this.form.optionsLabels.join());
       return this.form.optionsLabels.join() + this.form.minOptions + this.form.maxOptions;
     },
     ballot() {
@@ -84,25 +82,18 @@ export default {
       zero_supply = `${parseFloat(0).toFixed(
         supplyToDecimals(zero_supply)
       )} ${supplyToSymbol(zero_supply)}`
-
       return {
         treasury: this.treasury,
         description:
           this.form.IPFSString && this.form.IPFSString.trim() !== ''
             ? `${this.form.description} ${this.form.IPFSString}`
             : this.form.description,
-        content: this.form.imageUrl
-          ? `{\"imageUrl\":\"${this.form.imageUrl}\"}`
-          : '',
+        content: this.createContentField(),
         publisher: this.account,
         title: this.form.title,
         category: this.form.category,
         status: 'voting',
-        ballot_name: slugify(this.form.title, {
-          replacement: '-',
-          remove: /[*+~.()'"!:@?]/g,
-          lower: true,
-        }),
+        ballot_name: this.slugify(this.form.title),
         total_voters: 0,
         options: //[{key: "yes", value:"0.0000 VOTE"},{key: "no", value:"0.0000 VOTE"}]
         this.form.optionsLabels.map((key) => ({key, value:zero_supply})),
@@ -215,9 +206,39 @@ export default {
       }
     },
     validateImage(active) {
-      console.log('validateImage(',active,')');
       this.rules.setActive(active);
       this.$refs.img.validate();
+    },
+    slugify(text) {
+      return text
+        .toLowerCase()
+        .replace(/[^a-z12345]/gi, '')
+        .substring(0,12);
+    },
+    createContentField() {
+
+      // final object
+      let final = {
+        version: 'DCMSv2',
+        optionData: {}
+      };
+
+      // Option display texts
+      this.updateOptionValues().forEach((v,i) => {
+        final.optionData[v] = {displayText:this.form.optionsLabels[i]};
+      });
+
+      // image
+      if (this.form.imageUrl) {
+        final.imageUrls = [this.form.imageUrl];
+      }
+
+      // PDF hash
+      if (this.form.IPFSString) {
+        final.contentUrls = [this.form.IPFSString];
+      }
+
+      return JSON.stringify(final);
     },
     treasuryToOption(treasury) {
       if (!treasury) return null;
@@ -233,7 +254,6 @@ export default {
       let off_tr = this.treasuries.find((v) => v.symbol === 'VOTE');
       this.form.treasurySymbol = this.treasuryToOption(off_tr);
       this.form.config = 'votestake';
-      console.log('this.treasury', this.treasury);
     },
     isNewOptionRequired(val) {
       return !this.form.newOptionRequired || !!val || this.$t('forms.errors.required')
@@ -255,20 +275,10 @@ export default {
       this.form.optionsLabels = [];
     },
     updateOptionValues() {
-      console.log('updateOptionValues()');
-
-      this.form.optionsValues = this.form.optionsLabels.map(
-        t => slugify(t, {
-          replacement: '-',
-          remove: /[*+~.()'"!:@?]/g,
-          lower: true,
-        })
-      )
-
+      this.form.optionsValues = this.form.optionsLabels.map( t => this.slugify(t) )
       return this.form.optionsValues;
     },
     setDefaultOptions(num) {
-      console.log('setDefaultOptions()', num);
       this.form.optionsLabels = this.form.defaultLabels.map(t => t).filter((_,i) => i<num);
     },
     // empty functions BallotListItem, to use it as preview
@@ -363,15 +373,13 @@ export default {
           this.form.IPFSString && this.form.IPFSString.trim() !== ''
             ? `${this.form.description} ${this.form.IPFSString}`
             : this.form.description,
-        content: this.form.imageUrl
-          ? `{\"imageUrl\":\"${this.form.imageUrl}\"}`
-          : '',
+        content: this.createContentField(),
         treasurySymbol: this.form.treasurySymbol,
         votingMethod: this.form.votingMethod,
         maxOptions: this.form.maxOptions,
         minOptions: this.form.minOptions,
-        initialOptions: this.form.initialOptions,
-        endDate: this.form.endDate,
+        initialOptions: this.updateOptionValues(),
+        endDate: this.openForVoting ? this.form.endDate : null,
         config: this.form.config,
         settings: this.isStakeable,
       };
@@ -406,7 +414,6 @@ export default {
       }      
     },
     typeOfBallot() {
-      console.log('typeOfBallot()', this.typeOfBallot);
       switch(this.typeOfBallot) {
         case (TYPE_OF_BALLOT_0):
           this.setDefaultOptions(2);
@@ -429,12 +436,10 @@ export default {
       } 
     },
     optionsAsText() {
-      console.log('watch optionsAsText()');
       this.rules.setActive(true);
       this.validate({optionsLabels:1, minimun:1, maximun:1});
     },
     onlyOneOption() {
-      console.log('onlyOneOption()', this.typeOfBallot);
       if (!this.onlyOneOption) {
         this.form.minOptions = 1;
         this.form.maxOptions = this.form.optionsLabels.length;
@@ -449,7 +454,6 @@ export default {
     },
     show() {
       if (this.show) {
-        console.log('Show Ballot-creation wizzard');
         this.setOfficialDAO();
         this.rules.setActive(false);
         this.fetchFees();
@@ -458,7 +462,6 @@ export default {
       }
     },
     badImage() {
-      console.log('badImage():',this.badImage);
       this.validateImage(this.badImage);
     },
     'form.imageUrl'() {

--- a/src/pages/trails/ballots/components/BallotForm.vue
+++ b/src/pages/trails/ballots/components/BallotForm.vue
@@ -51,6 +51,7 @@ export default {
         initialOptions: [],
         endDate: moment(new Date()).add(20, 'days').format('YYYY-MM-DD HH:mm'),
         config: 'votestake',
+        file: null
       },
       prompt: false,
       userBalance: null,
@@ -67,13 +68,18 @@ export default {
         { value: 'referendum', label: 'Referendum' },
       ],
       submitting: false,
-      file: null,
       cid: null,
     };
   },
   computed: {
     ...mapGetters('trails', ['treasuries', 'userTreasury', 'ballotFees']),
     ...mapGetters('accounts', ['account','accountData']),
+    filename() {
+      if (!this.form.file) return '';
+      console.log('this.form.file: ', [this.form.file]);
+      console.log('this.form.file.name: ', typeof this.form.file.name , [this.form.file.name]);
+      return this.form.file.name;
+    },
     optionsAsText() {
       return this.form.optionsLabels.join() + this.form.minOptions + this.form.maxOptions;
     },
@@ -162,6 +168,10 @@ export default {
       'fetchTreasuriesForUser',
       'fetchFees',
     ]),
+    debug(){
+      console.log('BallotForm:', [this]);
+      console.log('BallotForm.form:', [this.form]);
+    },
     // auxiliar not-implemented-yet functions
     async nextStep() {
       console.error('nextStep()', this.step);
@@ -352,10 +362,10 @@ export default {
         initialOptions: [],
         endDate: moment(new Date()).add(20, 'days').format('YYYY-MM-DD HH:mm'),
         config: 'votestake',
+        file: null
       };
       this.step = 1;
       this.setOfficialDAO();
-      this.file = null;
       this.cid = null;
       this.rules.setActive(false);
     },
@@ -399,7 +409,7 @@ export default {
     },
   },
   watch: {
-    file: function () {
+    'form.file': function () {
       this.convertToIPFS(this.file);
     },
     account: async function (account) {
@@ -485,8 +495,8 @@ q-dialog(
     bordered
   )
 
-    q-card-section.bg-primary.text-white
-      .text-h6 Create a ballot
+    q-card-section.bg-primary.text-white(@click="debug")
+      .text-h6 Create a poll
 
     q-card-section
 
@@ -523,7 +533,7 @@ q-dialog(
               v-model="form.imageUrl"
               label="Image URL"
               placeholder="https://..."
-              hint="Upload an image and paste the url here to include it in your ballot."
+              hint="Upload an image and paste the url here to include it in your poll."
               :rules="[rules.required, (val) => !rules.isActive || !badImage || 'The image can not be load']"
             )
               template(v-slot:after v-if="form.imageUrl != ''")
@@ -532,7 +542,7 @@ q-dialog(
                     template(v-slot:error)
                       span.absolute-full.flex.flex-center.bg-negative.text-white.text-caption.q-pa-sm
                         | can not load image
-            q-file(v-model="file" label="Upload PDF")
+            q-file(v-model="form.file" label="Upload PDF")
               template(v-slot:prepend)
                 q-icon(name="attach_file")
         q-step(
@@ -771,6 +781,10 @@ q-dialog(
                 b description:
                 br
                 span {{form.description}}
+              .q-mt-sm
+                b PDF:&nbsp;
+                span(v-if="form.file") {{filename}}
+                span(v-if="!form.file") No pdf was attached
               .q-mt-sm
                 b DAO:&nbsp;
                 span {{form.treasurySymbol.label}}

--- a/src/pages/trails/ballots/components/BallotForm.vue
+++ b/src/pages/trails/ballots/components/BallotForm.vue
@@ -49,7 +49,7 @@ export default {
         maxOptions: 1,
         minOptions: 1,
         initialOptions: [],
-        endDate: moment(new Date()).add(20, 'days').format('YYYY-MM-DD HH:mm'),
+        endTime: moment(new Date()).add(20, 'days').format('YYYY-MM-DD HH:mm'),
         config: 'votestake',
         file: null
       },
@@ -176,7 +176,7 @@ export default {
         }
         case 4:
           if (this.openForVoting) {
-            list = {endDate:1};
+            list = {endTime:1};
           } else {
             list = {};
           }
@@ -323,7 +323,7 @@ export default {
         maxOptions: 1,
         minOptions: 1,
         initialOptions: [],
-        endDate: moment(new Date()).add(20, 'days').format('YYYY-MM-DD HH:mm'),
+        endTime: moment(new Date()).add(20, 'days').format('YYYY-MM-DD HH:mm'),
         config: 'votestake',
         file: null
       };
@@ -358,7 +358,7 @@ export default {
         maxOptions: this.form.maxOptions,
         minOptions: this.form.minOptions,
         initialOptions: this.updateOptionValues(),
-        endDate: this.openForVoting ? this.form.endDate : new Date(),
+        endTime: this.openForVoting ? this.form.endTime : new Date(),
         config: this.form.config,
         settings: this.isStakeable,
       };
@@ -406,6 +406,16 @@ export default {
   watch: {
     'form.file': function () {
       this.convertToIPFS(this.form.file);
+    },
+    'form.endTime'() {
+      if (!this.$refs.qDateProxy1 || this.$refs.qDateProxy2) return;
+      this.$refs.qDateProxy1.hide();
+      this.$refs.qDateProxy2.hide();
+    },
+    'form.imageUrl'() {
+      if (this.form.imageUrl == '') {
+        this.badImage = false;
+      }
     },
     account: async function (account) {
       this.fetchTreasuriesForUser(account);
@@ -455,7 +465,7 @@ export default {
     },
     openForVoting() {
       this.rules.setActive(this.openForVoting);
-      this.$refs.endDate.validate();
+      this.$refs.endTime.validate();
     },
     show() {
       if (this.show) {
@@ -470,11 +480,6 @@ export default {
     },
     badImage() {
       this.validateImage(this.badImage);
-    },
-    'form.imageUrl'() {
-      if (this.form.imageUrl == '') {
-        this.badImage = false;
-      }
     }
   },
   async mounted() {
@@ -731,25 +736,23 @@ q-dialog(
           p You can open this ballot for voting right away or you can create the ballot and skip this step for later.
           q-checkbox(v-model="openForVoting") Open for voting right away
           q-input(
-            ref="endDate"
-            v-model="form.endDate"
+            ref="endTime"
+            v-model="form.endTime"
             label="End date"
             :disable="!openForVoting"
             :rules="[rules.required, rules.dateFuture(Date.now())]"
           )
             template(v-slot:append)
               q-icon.cursor-pointer(name="event" color="primary")
-                q-popup-proxy(ref="qDateProxy" anchor="bottom left" self="top right" transition-show="scale" transition-hide="scale")
+                q-popup-proxy(ref="qDateProxy1" anchor="bottom left" self="top right" transition-show="scale" transition-hide="scale")
                   q-date(
-                    v-model="form.endDate"
-                    @input="() => $refs.qDateProxy.hide()"
+                    v-model="form.endTime"
                     mask="YYYY-MM-DD HH:mm"
                   )
               q-icon.cursor-pointer(name="access_time" color="primary")
-                q-popup-proxy(ref="qDateProxy" anchor="bottom left" self="top right" transition-show="scale" transition-hide="scale")
+                q-popup-proxy(ref="qDateProxy2" anchor="bottom left" self="top right" transition-show="scale" transition-hide="scale")
                   q-time(
-                    v-model="form.endDate"
-                    @input="() => $refs.qDateProxy.hide()"
+                    v-model="form.endTime"
                     mask="YYYY-MM-DD HH:mm"
                   )
         q-step(
@@ -765,7 +768,7 @@ q-dialog(
                 :isBallotOpened="false"
                 :startTimeHasPassed="false"
                 :getStartTime="getStartTime()"
-                :getEndTime="form.endDate"
+                :getEndTime="form.endTime"
                 :getLoser="false"
               )
             .col.flex.column.preview-right
@@ -796,7 +799,7 @@ q-dialog(
                     span(v-if="!onlyOneOption") Voters can choose from {{form.minOptions}} to {{form.maxOptions}} options
               .q-mt-sm
                 b open:&nbsp;
-                span(v-if="openForVoting") this ballot will be open from now until {{moment(form.endDate).format("MMMM Do YYYY")}}
+                span(v-if="openForVoting") this ballot will be open from now until {{moment(form.endTime).format("MMMM Do YYYY")}}
                 span(v-if="!openForVoting") this ballot will not open immediately and must be oppened manually in the future
         template(v-slot:navigation)
           q-stepper-navigation.flex

--- a/src/pages/trails/ballots/components/BallotForm.vue
+++ b/src/pages/trails/ballots/components/BallotForm.vue
@@ -746,7 +746,7 @@ q-dialog(
           :done="step > 4"
         )      
           p You can open this ballot for voting right away or you can create the ballot and skip this step for later.
-          q-checkbox(v-model="openForVoting") Open for voting right away
+          q-checkbox(v-model="openForVoting" disable) Open for voting right away
           q-input(
             ref="endDate"
             v-model="form.endDate"
@@ -769,6 +769,7 @@ q-dialog(
                     @input="() => $refs.qDateProxy.hide()"
                     mask="YYYY-MM-DD HH:mm"
                   )
+          small Note: Proposals will be eligible for voting once they are created.
         q-step(
           :name="5"
           title="Create Ballot"

--- a/src/pages/trails/ballots/components/BallotForm.vue
+++ b/src/pages/trails/ballots/components/BallotForm.vue
@@ -30,8 +30,8 @@ export default {
       typeOfBallot: TYPE_OF_BALLOT_0,
       ballotTypes: [TYPE_OF_BALLOT_0, TYPE_OF_BALLOT_1, TYPE_OF_BALLOT_2],
       isBallotListRowDirection: true,
+      openForVoting: true,
       form: {
-        openForVoting: true,
         onlyOneOption: true,
         newOptionLabel: '',
         newOptionValue: '',
@@ -248,8 +248,8 @@ export default {
       }
 
       let final_str = JSON.stringify(final);
-      console.log("final: ", [final]);
-      console.log("final_str: ", [final_str]);
+      console.log('final: ', [final]);
+      console.log('final_str: ', [final_str]);
 
       return final_str;
     },
@@ -408,8 +408,8 @@ export default {
         const ipfs = await IPFS.create();
         this.cid = await ipfs.add(file);
 
-        console.log("convertToIPFS() this.cid.path: ", this.cid.path);
-        console.log("convertToIPFS() this.form.IPFSString: ", this.form.IPFSString);
+        console.log('convertToIPFS() this.cid.path: ', this.cid.path);
+        console.log('convertToIPFS() this.form.IPFSString: ', this.form.IPFSString);
       } catch (e) {
         if (e.code == 'ERR_LOCK_EXISTS') return;
         console.error(e);

--- a/src/pages/trails/ballots/components/BallotForm.vue
+++ b/src/pages/trails/ballots/components/BallotForm.vue
@@ -1,10 +1,20 @@
 <script>
-import { mapActions, mapGetters } from 'vuex';
-import { validation } from '~/mixins/validation';
-import * as IPFS from 'ipfs-core';
+import { mapActions, mapGetters } from "vuex";
+import { validation } from "~/mixins/validation";
+import * as IPFS from "ipfs-core";
+import BallotListItem from "~/pages/trails/ballots/components/BallotListItem";
+import moment from "moment";
+import { ref } from 'vue'
+
+const TYPE_OF_BALLOT_0 = "yes.no";
+const TYPE_OF_BALLOT_1 = "yes.no.abst";
+const TYPE_OF_BALLOT_2 = "multi.op";
 
 export default {
-  name: 'BallotForm',
+  name: "BallotForm",
+  components: {
+    BallotListItem,
+  },
   mixins: [validation],
   props: {
     show: { type: Boolean, required: true },
@@ -12,15 +22,28 @@ export default {
   emits: ['close'],
   data() {
     return {
+      moment: moment,
+      step: ref(1),
+      isOfficial: true,
+      typeOfBallot: TYPE_OF_BALLOT_0,
+      ballotTypes: [TYPE_OF_BALLOT_0, TYPE_OF_BALLOT_1, TYPE_OF_BALLOT_2],
+      isBallotListRowDirection: true,
       form: {
+        openForVoting: true,
+        onlyOneOption: true,
+        newOptionLabel: "",
+        newOptionValue: "",
+        defaultLabels:["Yes", "No", "Abstain"],
+        optionsLabels:["Yes", "No", "Abstain"],
+        optionsValues:["yes", "no", "abstain"],
         title: null,
         category: 'poll',
         description: null,
         imageUrl: null,
         IPFSString: null,
         treasurySymbol: null,
-        votingMethod: '1token1vote',
-        maxOptions: 1,
+        votingMethod: "1token1vote",
+        maxOptions: 3,
         minOptions: 1,
         initialOptions: [],
         endDate: null,
@@ -46,8 +69,28 @@ export default {
     };
   },
   computed: {
-    ...mapGetters('trails', ['treasuries', 'userTreasury', 'ballotFees']),
-    ...mapGetters('accounts', ['account','accountData']),
+    ...mapGetters("trails", ["treasuries", "userTreasury", "ballotFees"]),
+    ...mapGetters("accounts", ["account","accountData"]),
+    ballot() {
+      return {
+        treasury: {
+          title: "Telos Governance Token",
+          icon: "https://raw.githubusercontent.com/telosnetwork/images/master/chain_icons/telos-logo-light.svg",
+        },
+        content : JSON.stringify({
+          "imageUrl":"https://www.foodnewslatam.com/images/stories/2022/AGOSTO/Coca-Cola_planea_seguir_reduciendo_el_azu%CC%81car_en_sus_bebidas.png"
+        }),
+        publisher: "publisher",
+        description:"Esta es la descripción del Ballot QmSAVK6dorHMfxk3sGRjHWVfxDkazUtfXifxvvYBDs3bvL",
+        title: "Ballot Title",
+        category: 'poll',
+        status: 'new',
+        ballot_name: 'ballotname',
+        total_voters: 0,
+        options: [{key: "yes", value:"0.0000 VOTE"},{key: "no", value:"0.0000 VOTE"}],
+        total_raw_weight: "0.0000 VOTE"
+      }
+    },
     getTreasurySymbols() {
       if (this.userTreasury) {
         const symbols = this.userTreasury.map((treasury) => ({
@@ -101,6 +144,51 @@ export default {
       'fetchTreasuriesForUser',
       'fetchFees',
     ]),
+    // auxiliar not-implemented-yet functions
+    addOption() {
+      // TODO: implement this function
+      console.log("addOption() implement me !!");
+    },
+    deleteOption(index) {
+      // TODO: implement this function
+      console.log("deleteOption() implement me !!", index);
+    },
+    cleanOptions(index) {
+      // TODO: implement this function
+      console.log("cleanOptions() implement me !!", index);
+    },
+    // empty functions BallotListItem, to use it as preview
+    displayWinner(ballot) {
+      if (!ballot) return false;
+      return false;
+    },
+    getLoser() {
+      return false;
+    },
+    isBallotOpened(ballot) {
+      if (!ballot) return false;
+      return false;
+    },
+    votingHasBegun(ballot) {
+      if (!ballot) return false;
+      return false;
+    },
+    getStartTime(ballot) {
+      if (!ballot) return new Date();
+      return new Date();
+    },
+    getEndTime(ballot) {
+      if (!ballot) return new Date();
+      return new Date();
+    },
+    ballotContentImg(ballot) {
+      // TODO: refactor needed. This function is copied from BallotsList.vue
+      try {
+        return JSON.parse(ballot.content).imageUrl;
+      } catch (error) {
+        return null;
+      }
+    },
     async onAddBallot() {
       this.submitting = true;
       const success = await this.addBallot(this.createBallotObject());
@@ -131,7 +219,6 @@ export default {
       this.cid = null;
     },
     onCancel() {
-      this.resetBallot();
       this.$emit('close');
     },
     addBallotOption(val, done) {
@@ -187,6 +274,20 @@ export default {
         this.form.IPFSString = null;
       }      
     },
+    typeOfBallot() {
+      console.log("typeOfBallot--");
+      switch(this.typeOfBallot) {
+        case (TYPE_OF_BALLOT_0): 
+          break;
+        case (TYPE_OF_BALLOT_1): 
+          break;
+        case (TYPE_OF_BALLOT_2): 
+          break;
+        default: // ??
+          console.error("ERORR: check consistency! ", [this.typeOfBallot, this.ballotTypes]);
+          break;
+      }      
+    }
   },
   mounted() {
     this.fetchFees();
@@ -201,11 +302,400 @@ q-dialog(
   v-model="show"
   persistent
 )
-  q-card(
+  q-card.container-md(
     flat
     bordered
-    style="width: 400px; max-width: 80vw;"
   )
+
+    q-card-section.bg-primary.text-white
+      .text-h6 Create a ballot
+
+    q-card-section
+
+      q-stepper(
+        v-model="step"
+        header-nav
+        ref="stepper"
+        color="primary"
+        animated
+        style="min-height:80vh"
+      )
+        q-step(
+          :name="1"
+          title="Ballot main info"
+          icon="info"
+          :done="step > 1"
+        )
+          q-card-section
+            q-input(
+              ref="title"
+              v-model="form.title"
+              label="Title"
+            )
+            // :rules="[rules.required]"
+            q-input(
+              ref="description"
+              v-model="form.description"
+              label="Description"
+              type="textarea"
+            )
+            // :rules="[rules.required]"
+            q-input(
+              class="q-mb-md"
+              ref="img"
+              v-model="form.imageUrl"
+              label="Image URL"
+              placeholder="https://..."
+              hint="Upload an image and paste the url here to include it in your ballot."
+            )
+            // :rules="[rules.required]"
+            q-file(v-model="file" label="Upload PDF")
+              template(v-slot:prepend)
+                q-icon(name="attach_file")
+        q-step(
+          :name="2"
+          title="DAO selection"
+          caption="Optional"
+          icon="group"
+          :done="step > 2"
+        )
+          q-card-section
+            span
+              | Select DAO
+            .row.gap-sm
+              q-radio(
+                v-model="isOfficial"
+                label="Telos community"
+                :val="true"
+              )
+              q-radio(
+                v-model="isOfficial"
+                label="Custom DAO"
+                :val="false"
+              )
+            div.q-mt-sm.column(:class="isOfficial ? '' : 'hidden'")
+              p
+                | By selecting the Telos Community as DAO you will allow all users of our beloved community to vote in this ballot.
+                | The voting power of each user will come from the TLOS staked balance plus the staked TLOS in the REX system.
+            div.q-mt-sm.column(:class="isOfficial ? 'hidden' : ''")
+              p
+                | By selecting Custom DAO, you will allow only registered users of this DAO to vote in this ballot.
+                | Select the DAO from the one you are already part of or join a new ballot to create a ballot for.
+              .row.items-center.gap
+                q-select.col-grow(
+                  ref="treasurySymbol"
+                  v-model="form.treasurySymbol"
+                  label="Treasury"
+                  :options="getTreasurySymbols"
+                  :rules="[rules.required]"
+                )
+                q-btn.col-auto(
+                  no-caps
+                  color="primary"
+                  label="Join new DAO"
+                  to="/trails/treasuries"
+                )
+              span.q-mt-sm
+                | Allow users voting using
+              .row.gap-sm
+                q-radio(
+                  v-model="form.config"
+                  label="Only stakeble tokens"
+                  val="votestake"
+                )
+                q-radio(
+                  v-model="form.config"
+                  label="Only liquid tokens"
+                  val="voteliquid"
+                )
+                q-radio(
+                  v-model="form.config"
+                  label="Both"
+                  val="both"
+                )            
+        q-step(
+          :name="3"
+          title="Voting options"
+          icon="list"
+          :done="step > 3"
+        )
+          q-card-section
+            span
+              | What kind of ballot do you want?
+            .row.gap-sm
+              q-radio(
+                v-model="typeOfBallot"
+                label="Simple Yes or No"
+                :val="ballotTypes[0]"
+              )
+              q-radio(
+                v-model="typeOfBallot"
+                label="Yes/No/Abstain"
+                :val="ballotTypes[1]"
+              )
+              q-radio(
+                v-model="typeOfBallot"
+                label="Multiple option"
+                :val="ballotTypes[2]"
+              )
+            div(:class="typeOfBallot == ballotTypes[0] ? '' : 'hidden'")
+              | Simple binary ballots only have two options to vote for.
+              | By default we use the words
+              b  Yes
+              |  and
+              b  No
+              | , but you can change them if you want.
+              .q-mt-sm.raw.flex.gap
+                q-input.col-grow(
+                  v-model="form.defaultLabels[0]"
+                  label="option 1"
+                )
+                q-input.col-grow(
+                  v-model="form.defaultLabels[1]"
+                  label="option 2"
+                )
+            div(:class="typeOfBallot == ballotTypes[1] ? '' : 'hidden'")
+              | This kind of ballot is the same as the binary one but has three options to vote for.
+              | By default we use the words
+              b  Yes
+              |  ,
+              b  No
+              |  and
+              b  Abstain
+              | , but you can change them if you want.
+              .q-mt-sm.raw.flex.gap
+                q-input.col-grow(
+                  v-model="form.defaultLabels[0]"
+                  label="option 1"
+                )
+                q-input.col-grow(
+                  v-model="form.defaultLabels[1]"
+                  label="option 2"
+                )
+                q-input.col-grow(
+                  v-model="form.defaultLabels[2]"
+                  label="option 3"
+                )
+            div(:class="typeOfBallot == ballotTypes[2] ? '' : 'hidden'")
+              | Multiple option ballots are completely configurable.
+              | You can define a list of several options to vote for, with human readability names,
+              | where voters may be allowed to check none or more than one option simultaneously in the same vote.
+              .q-mt-sm.flex.row.gap
+                .col.flex.column.options-left
+                  .flex.row.items-center.gap.options-left__header
+                    q-input.col-grow( v-model="form.newOptionLabel" label="new option" bottom-slots )
+                      template(v-slot:append)
+                        q-btn(no-caps color="primary" icon="add" label="add" @click="addOption()")
+                  .flex.column.q-pa-md.options-left__options-list
+                    .flex.row.items-center.options-left__option(v-for="(coso,index) in form.optionsLabels")
+                      q-input.col-grow.options-left__option-label(:dense="true" bottom-slots v-model="form.optionsLabels[index]" )
+                        template(v-slot:append)
+                          q-icon.cursor-pointer(name="close" @click="deleteOption(index)")
+                  .flex.row.justify-between
+                    q-checkbox(v-model="form.onlyOneOption" v-if="form.onlyOneOption") Voters can only choose one option
+                    div
+                    q-btn(no-caps color="primary" icon="delete_sweep" label="Clean" @click="cleanOptions()")
+                .col.flex.column.options-right(v-if="!form.onlyOneOption")
+                  q-checkbox(v-model="form.onlyOneOption") Voters can only choose one option
+                  div.q-mt-sm
+                    | You are allowing voters to check several options (or none) in the same vote. Now you should set the maximum and minimum.
+                    br
+                    | For example, if you need to select two members from five options, your max and min should both equal 2.
+                    | However, if you want to know what colors people like from a list, you will put the min at zero and the max high enough to select them all.
+                  .flex.row.q-mt-sm.options-right__howmany
+                    q-input.col-auto.options-right__howmany-min( v-model="form.minOptions" label="minimun" )
+                    q-input.col-auto.options-right__howmany-max( v-model="form.maxOptions" label="maximun" )
+        q-step(
+          :name="4"
+          title="Open Voting"
+          icon="how_to_vote"
+          :done="step > 4"
+        )      
+          p You can open this ballot for voting right away or you can create the ballot and skip this step for later.
+          q-checkbox(v-model="form.openForVoting") Open for voting right away
+          q-input(
+            ref="endDate"
+            v-model="form.endDate"
+            label="End date"
+            :disable="!form.openForVoting"
+          )
+            // :rules="[rules.required, rules.dateFuture(Date.now())]"
+            template(v-slot:append)
+              q-icon.cursor-pointer(name="event" color="primary")
+                q-popup-proxy(ref="qDateProxy" anchor="bottom left" self="top right" transition-show="scale" transition-hide="scale")
+                  q-date(
+                    v-model="form.endDate"
+                    @input="() => $refs.qDateProxy.hide()"
+                    mask="YYYY-MM-DD HH:mm"
+                  )
+              q-icon.cursor-pointer(name="access_time" color="primary")
+                q-popup-proxy(ref="qDateProxy" anchor="bottom left" self="top right" transition-show="scale" transition-hide="scale")
+                  q-time(
+                    v-model="form.endDate"
+                    @input="() => $refs.qDateProxy.hide()"
+                    mask="YYYY-MM-DD HH:mm"
+                  )
+        q-step(
+          :name="5"
+          title="Create Ballot"
+          icon="check"
+        )      
+          .q-mt-sm.flex.row.gap
+            .col.flex.column.preview-left(:class="isBallotListRowDirection ? 'row-direction' : 'column-direction'")
+              ballot-list-item(
+                :ballot="ballot"
+                :displayWinner="displayWinner"
+                :isBallotOpened="false"
+                :votingHasBegun="false"
+                :getStartTime="getStartTime()"
+                :getEndTime="getEndTime()"
+                :getLoser="getLoser"
+                :ballotContentImg="ballotContentImg"
+              )
+            .col.flex.column.preview-right
+              .q-mt-sm
+                b title:
+                br
+                span Título del propsal
+              .q-mt-sm
+                b description:
+                br
+                span Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+              .q-mt-sm
+                b DAO:&nbsp;
+                span Telos Governance Token
+              .q-mt-sm
+                b options:
+                br
+                ul.q-mt-xs
+                  li Yes
+                  li No
+                  li Abstain
+                span Voters only can choose one option
+              .q-mt-sm
+                b open:&nbsp;
+                span this ballot will be open from now until {{moment(getEndTime()).format("MMMM Do YYYY")}}
+        template(v-slot:navigation)
+          q-stepper-navigation.flex
+            q-btn.q-ml-sm(color="primary" label="Back"     flat v-if="step > 1" @click="$refs.stepper.previous()")
+            .col-grow
+            q-btn.q-ml-sm(color="primary" label="Cancel"   flat @click="onCancel()")
+            q-btn.q-ml-sm(color="primary" label="Continue" v-if="step !== 5" @click="$refs.stepper.next()")
+            q-btn.q-ml-sm(color="primary" label="Finish"   v-if="step === 5" @click="onAddBallot()")
+
+
+
+
+
+
+//
+      q-input(
+        ref="title"
+        v-model="form.title"
+        label="Title"
+        :rules="[rules.required]"
+      )
+      q-input(
+        ref="description"
+        v-model="form.description"
+        label="Description"
+        type="textarea"
+        :rules="[rules.required]"
+      )
+      q-input(
+        class="q-mb-md"
+        ref="img"
+        v-model="form.imageUrl"
+        label="Image URL"
+        placeholder="https://..."
+        hint="Upload an image and paste the url here to include it in your ballot."
+        :rules="[rules.required]"
+      )
+      q-file(v-model="file" label="Upload PDF")
+        template(v-slot:prepend)
+          q-icon(name="attach_file")
+      .row
+        q-radio(
+          v-model="form.config"
+          label="Simple Yes or No"
+          val="votestake"
+          hint="A simple ballot with only two options to vote for. By default, the words 'Yes' and 'No' are used but you can change them."
+        )
+        q-radio(
+          v-model="form.config"
+          label="Yes/No/Abstain"
+          val="asddd"
+        )
+        q-radio(
+          v-model="form.config"
+          label="Multiple option"
+          val="voteliquid"
+        )
+      .row A simple ballot with only two options to vote for. By default, the words 'Yes' and 'No' are used but you can change them.
+        
+      q-input(
+        ref="endDate"
+        v-model="form.endDate"
+        label="End date"
+        :rules="[rules.required, rules.dateFuture(Date.now())]"
+      )
+        template(v-slot:append)
+          q-icon.cursor-pointer(name="event")
+            q-popup-proxy(ref="qDateProxy" transition-show="scale" transition-hide="scale")
+              q-date(
+                v-model="form.endDate"
+                @input="() => $refs.qDateProxy.hide()"
+                mask="YYYY-MM-DD HH:mm"
+              )
+          q-icon.cursor-pointer(name="access_time")
+            q-popup-proxy(ref="qDateProxy" transition-show="scale" transition-hide="scale")
+              q-time(
+                v-model="form.endDate"
+                @input="() => $refs.qDateProxy.hide()"
+                mask="YYYY-MM-DD HH:mm"
+              )
+    q-card-actions(align="right")
+      q-btn(
+        flat
+        :label="$t('common.buttons.cancel')"
+        @click="onCancel()"
+      )
+      q-btn(
+        color="primary"
+        :label="$t('common.buttons.create')"
+        :loading="submitting"
+        @click="openConfirmation()"
+      )
+    q-dialog(
+      v-model="prompt"
+      persistent
+    )
+      q-card(
+        style="min-width: 350px"
+      )
+        q-card-section.row.items-center
+          span.q-ml-sm(
+            v-if="available"
+          ) There will be a {{fee}} fee for creating a ballot.
+          span.q-ml-sm(
+            v-else
+          ) {{ "Insufficient balance to create a ballot." }}
+        q-card-actions.text-primary(
+          align="right"
+        )
+          q-btn(
+            flat
+            label="Cancel"
+            v-close-popup
+          )
+          q-btn(
+            v-if="available"
+            flat
+            label="Accept"
+            v-close-popup
+            @click="onAddBallot()"
+          )
+
 
     q-card-section.bg-primary.text-white
       .text-h6 Create a ballot
@@ -369,4 +859,13 @@ q-dialog(
             @click="onAddBallot()"
           )
 </template>
-<style scoped></style>
+<style scoped lang="sass">
+.q-stepper--horizontal
+  display: flex
+  flex-direction: column
+.q-stepper__nav
+  flex-grow: 1
+  align-items: end
+
+</style>
+

--- a/src/pages/trails/ballots/components/BallotForm.vue
+++ b/src/pages/trails/ballots/components/BallotForm.vue
@@ -1,17 +1,20 @@
 <script>
-import { mapActions, mapGetters } from "vuex";
-import { validation } from "~/mixins/validation";
-import * as IPFS from "ipfs-core";
-import BallotListItem from "~/pages/trails/ballots/components/BallotListItem";
-import moment from "moment";
+import { mapActions, mapGetters } from 'vuex';
+import { validation } from '~/mixins/validation';
+import * as IPFS from 'ipfs-core';
+import BallotListItem from '~/pages/trails/ballots/components/BallotListItem';
+import moment from 'moment';
 import { ref } from 'vue'
+import slugify from 'slugify';
+import { supplyToDecimals, supplyToSymbol } from '~/utils/assets';
 
-const TYPE_OF_BALLOT_0 = "yes.no";
-const TYPE_OF_BALLOT_1 = "yes.no.abst";
-const TYPE_OF_BALLOT_2 = "multi.op";
+
+const TYPE_OF_BALLOT_0 = 'yes.no';
+const TYPE_OF_BALLOT_1 = 'yes.no.abst';
+const TYPE_OF_BALLOT_2 = 'multi.op';
 
 export default {
-  name: "BallotForm",
+  name: 'BallotForm',
   components: {
     BallotListItem,
   },
@@ -31,22 +34,23 @@ export default {
       form: {
         openForVoting: true,
         onlyOneOption: true,
-        newOptionLabel: "",
-        newOptionValue: "",
-        defaultLabels:["Yes", "No", "Abstain"],
-        optionsLabels:["Yes", "No", "Abstain"],
-        optionsValues:["yes", "no", "abstain"],
-        title: null,
+        newOptionLabel: '',
+        newOptionValue: '',
+        defaultLabels:['Yes', 'No', 'Abstain'],
+        optionsLabels:['Yes', 'No'],
+        optionsValues:['yes', 'no'],
+        optionsError: '',
+        title: '',
         category: 'poll',
-        description: null,
-        imageUrl: null,
+        description: '',
+        imageUrl: '',
         IPFSString: null,
         treasurySymbol: null,
-        votingMethod: "1token1vote",
+        votingMethod: '1token1vote',
         maxOptions: 3,
         minOptions: 1,
         initialOptions: [],
-        endDate: null,
+        endDate: moment(new Date()).add(20, 'days').format('YYYY-MM-DD HH:mm'),
         config: 'votestake',
       },
       prompt: false,
@@ -69,49 +73,72 @@ export default {
     };
   },
   computed: {
-    ...mapGetters("trails", ["treasuries", "userTreasury", "ballotFees"]),
-    ...mapGetters("accounts", ["account","accountData"]),
+    ...mapGetters('trails', ['treasuries', 'userTreasury', 'ballotFees']),
+    ...mapGetters('accounts', ['account','accountData']),
+    optionsAsText() {
+      console.log('computed optionsAsText() ->', this.form.optionsLabels.join());
+      return this.form.optionsLabels.join() + this.form.minOptions + this.form.maxOptions;
+    },
     ballot() {
+      let zero_supply = this.treasury.max_supply;
+      zero_supply = `${parseFloat(0).toFixed(
+        supplyToDecimals(zero_supply)
+      )} ${supplyToSymbol(zero_supply)}`
+
       return {
-        treasury: {
-          title: "Telos Governance Token",
-          icon: "https://raw.githubusercontent.com/telosnetwork/images/master/chain_icons/telos-logo-light.svg",
-        },
-        content : JSON.stringify({
-          "imageUrl":"https://www.foodnewslatam.com/images/stories/2022/AGOSTO/Coca-Cola_planea_seguir_reduciendo_el_azu%CC%81car_en_sus_bebidas.png"
+        treasury: this.treasury,
+        description:
+          this.form.IPFSString && this.form.IPFSString.trim() !== ''
+            ? `${this.form.description} ${this.form.IPFSString}`
+            : this.form.description,
+        content: this.form.imageUrl
+          ? `{\"imageUrl\":\"${this.form.imageUrl}\"}`
+          : '',
+        publisher: this.account,
+        title: this.form.title,
+        category: this.form.category,
+        status: 'voting',
+        ballot_name: slugify(this.form.title, {
+          replacement: '-',
+          remove: /[*+~.()'"!:@?]/g,
+          lower: true,
         }),
-        publisher: "publisher",
-        description:"Esta es la descripción del Ballot QmSAVK6dorHMfxk3sGRjHWVfxDkazUtfXifxvvYBDs3bvL",
-        title: "Ballot Title",
-        category: 'poll',
-        status: 'new',
-        ballot_name: 'ballotname',
         total_voters: 0,
-        options: [{key: "yes", value:"0.0000 VOTE"},{key: "no", value:"0.0000 VOTE"}],
-        total_raw_weight: "0.0000 VOTE"
+        options: //[{key: "yes", value:"0.0000 VOTE"},{key: "no", value:"0.0000 VOTE"}]
+        this.form.optionsLabels.map((key) => ({key, value:zero_supply})),
+        total_raw_weight: zero_supply
       }
     },
+    treasury() {
+      if (!this.form.treasurySymbol) return null;
+      return this.treasuries.find(
+        (t) => t.symbol === this.form.treasurySymbol.symbol
+      )
+    },
     getTreasurySymbols() {
+      let result = [];
       if (this.userTreasury) {
         const symbols = this.userTreasury.map((treasury) => ({
           symbol: treasury.delegated.replace(/[^a-zA-Z]/gi, ''),
         }));
-        return this.treasuries
+        result = this.treasuries
           .filter((v) => {
             return symbols.some((v2) => {
-              return v.symbol === v2.symbol;
+              return v.symbol === v2.symbol && v.symbol !== 'VOTE'
             });
           })
-          .map((treasury) => ({
-            label: treasury.title
-              ? `${treasury.title} (${treasury.supply})`
-              : treasury.supply,
-            value: treasury.supply,
-            symbol: treasury.supply.replace(/[^a-zA-Z]/gi, ''),
-          }));
-      } else {
-        return null;
+          .map(this.treasuryToOption);
       }
+
+      if (result.length == 0) {
+        result = [{
+          label: 'You are not registered to any private DAO',
+          value: null,
+          disable: true
+        }];
+      }
+
+      return result;
     },
     isStakeable() {
       let selectedTreasurySettings = this.treasuries.find(
@@ -145,17 +172,104 @@ export default {
       'fetchFees',
     ]),
     // auxiliar not-implemented-yet functions
+    async nextStep() {
+      console.error('nextStep()', this.step);
+      if (this.step >= 5) return;
+      let list = {};
+      switch(this.step) {
+        case 1: {
+          list = {title:1, description:1, img:1};
+          break;
+        }
+        case 2: {
+          list = {treasurySymbol:1};
+          break;
+        }
+        case 3: {
+          if (this.typeOfBallot == this.ballotTypes[0]) {
+            list = {op_a_1:1,op_a_2:1};
+          } else if (this.typeOfBallot == this.ballotTypes[1]) {
+            list = {op_b_1:1,op_b_2:1,op_b_3:1};
+          } else if (this.typeOfBallot == this.ballotTypes[2]) {
+            list = {optionsLabels:1, minimun:1, maximun:1};
+          }
+          break;
+        }
+        case 4:
+          if (this.openForVoting) {
+            list = {endDate:1};
+          } else {
+            list = {};
+          }
+      }
+      this.rules.setActive(true);
+      let ok = await this.validate(list);
+      if (ok) {
+        this.rules.setActive(false);
+        this.$refs.stepper.next();
+      } else {
+        console.error('errors:');
+        Object.keys(list).forEach(t => {
+          console.error('-', t, this.$refs[t].hasError);
+        });
+      }
+    },
+    validateImage(active) {
+      console.log('validateImage(',active,')');
+      this.rules.setActive(active);
+      this.$refs.img.validate();
+    },
+    treasuryToOption(treasury) {
+      if (!treasury) return null;
+      return {
+        label: treasury.title
+          ? `${treasury.title} (${treasury.supply})`
+          : treasury.supply,
+        value: treasury.supply,
+        symbol: treasury.supply.replace(/[^a-zA-Z]/gi, ''),
+      };
+    },
+    setOfficialDAO() {
+      let off_tr = this.treasuries.find((v) => v.symbol === 'VOTE');
+      this.form.treasurySymbol = this.treasuryToOption(off_tr);
+      this.form.config = 'votestake';
+      console.log('this.treasury', this.treasury);
+    },
+    isNewOptionRequired(val) {
+      return !this.form.newOptionRequired || !!val || this.$t('forms.errors.required')
+    },
     addOption() {
-      // TODO: implement this function
-      console.log("addOption() implement me !!");
+      // if not newOptionLabel then alert the error and require the field to be tot empty
+      this.form.newOptionRequired = this.form.newOptionLabel === '';
+      if (this.form.newOptionLabel) {
+        this.form.optionsLabels.push(this.form.newOptionLabel);
+        this.form.newOptionLabel = '';
+      } else {
+        this.$refs.newOptionInput.validate();
+      }
     },
     deleteOption(index) {
-      // TODO: implement this function
-      console.log("deleteOption() implement me !!", index);
+      this.form.optionsLabels.splice(index,1);
     },
-    cleanOptions(index) {
-      // TODO: implement this function
-      console.log("cleanOptions() implement me !!", index);
+    cleanOptions() {
+      this.form.optionsLabels = [];
+    },
+    updateOptionValues() {
+      console.log('updateOptionValues()');
+
+      this.form.optionsValues = this.form.optionsLabels.map(
+        t => slugify(t, {
+          replacement: '-',
+          remove: /[*+~.()'"!:@?]/g,
+          lower: true,
+        })
+      )
+
+      return this.form.optionsValues;
+    },
+    setDefaultOptions(num) {
+      console.log('setDefaultOptions()', num);
+      this.form.optionsLabels = this.form.defaultLabels.map(t => t).filter((_,i) => i<num);
     },
     // empty functions BallotListItem, to use it as preview
     displayWinner(ballot) {
@@ -194,8 +308,13 @@ export default {
       const success = await this.addBallot(this.createBallotObject());
       this.submitting = false;
       if (success) {
-        this.$emit('update:show', false);
+        let url = `/trails/ballot/${this.ballot.ballot_name}/${Date.now()}`;
+        this.$emit('close');
         this.resetBallot();
+        setTimeout(() => {
+          this.$router.push(url);
+        }, 1000);
+        
       }
     },
     async openConfirmation() {
@@ -205,18 +324,30 @@ export default {
     },
     resetBallot() {
       this.form = {
-        title: null,
-        category: null,
-        description: null,
-        imageUrl: null,
+        newOptionLabel: '',
+        newOptionRequired: false,
+        defaultLabels:['Yes', 'No', 'Abstain'],
+        optionsLabels:['Yes', 'No'],
+        optionsValues:['yes', 'no'],
+        optionsError: '',
+        title: '',
+        category: 'poll',
+        description: '',
+        imageUrl: '',
+        IPFSString: null,
         treasurySymbol: null,
         votingMethod: '1token1vote',
+        maxOptions: 3,
+        minOptions: 1,
         initialOptions: [],
-        endDate: null,
-        IPFSString: null,
+        endDate: moment(new Date()).add(20, 'days').format('YYYY-MM-DD HH:mm'),
+        config: 'votestake',
       };
+      this.step = 1;
+      this.setOfficialDAO();
       this.file = null;
       this.cid = null;
+      this.rules.setActive(false);
     },
     onCancel() {
       this.$emit('close');
@@ -275,24 +406,68 @@ export default {
       }      
     },
     typeOfBallot() {
-      console.log("typeOfBallot--");
+      console.log('typeOfBallot()', this.typeOfBallot);
       switch(this.typeOfBallot) {
-        case (TYPE_OF_BALLOT_0): 
+        case (TYPE_OF_BALLOT_0):
+          this.setDefaultOptions(2);
           break;
-        case (TYPE_OF_BALLOT_1): 
+        case (TYPE_OF_BALLOT_1):
+        this.setDefaultOptions(3);
           break;
         case (TYPE_OF_BALLOT_2): 
           break;
         default: // ??
-          console.error("ERORR: check consistency! ", [this.typeOfBallot, this.ballotTypes]);
+          console.error('ERORR: check consistency! ', [this.typeOfBallot, this.ballotTypes]);
           break;
       }      
+    },
+    isOfficial() {
+      if (this.isOfficial) {
+        this.setOfficialDAO();
+      } else {
+        this.form.treasurySymbol = null;
+      } 
+    },
+    optionsAsText() {
+      console.log('watch optionsAsText()');
+      this.rules.setActive(true);
+      this.validate({optionsLabels:1, minimun:1, maximun:1});
+    },
+    onlyOneOption() {
+      console.log('onlyOneOption()', this.typeOfBallot);
+      if (!this.onlyOneOption) {
+        this.form.minOptions = 1;
+        this.form.maxOptions = this.form.optionsLabels.length;
+      } else {
+        this.form.minOptions = 1;
+        this.form.maxOptions = 1;
+      }
+    },
+    openForVoting() {
+      this.rules.setActive(this.openForVoting);
+      this.$refs.endDate.validate();
+    },
+    show() {
+      if (this.show) {
+        console.log('Show Ballot-creation wizzard');
+        this.setOfficialDAO();
+        this.rules.setActive(false);
+        this.fetchFees();
+        this.updateUserBalance();
+        this.fetchTreasuriesForUser(this.account);
+      }
+    },
+    badImage() {
+      console.log('badImage():',this.badImage);
+      this.validateImage(this.badImage);
+    },
+    'form.imageUrl'() {
+      if (this.form.imageUrl == '') {
+        this.badImage = false;
+      }
     }
   },
-  mounted() {
-    this.fetchFees();
-    this.updateUserBalance();
-    this.fetchTreasuriesForUser(this.account);
+  async mounted() {
   },
 };
 </script>
@@ -312,13 +487,12 @@ q-dialog(
 
     q-card-section
 
-      q-stepper(
+      q-stepper.ballot-creation(
         v-model="step"
         header-nav
         ref="stepper"
         color="primary"
         animated
-        style="min-height:80vh"
       )
         q-step(
           :name="1"
@@ -331,15 +505,15 @@ q-dialog(
               ref="title"
               v-model="form.title"
               label="Title"
+              :rules="[rules.required]"
             )
-            // :rules="[rules.required]"
             q-input(
               ref="description"
               v-model="form.description"
               label="Description"
               type="textarea"
+              :rules="[rules.required]"
             )
-            // :rules="[rules.required]"
             q-input(
               class="q-mb-md"
               ref="img"
@@ -347,8 +521,14 @@ q-dialog(
               label="Image URL"
               placeholder="https://..."
               hint="Upload an image and paste the url here to include it in your ballot."
+              :rules="[rules.required, (val) => !rules.isActive || !badImage || 'The image can not be load']"
             )
-            // :rules="[rules.required]"
+              template(v-slot:after v-if="form.imageUrl != ''")
+                div(style="height: 50px; width: 100px;")
+                  q-img(:src="form.imageUrl" @error="badImage=true" @load="badImage=false")
+                    template(v-slot:error)
+                      span.absolute-full.flex.flex-center.bg-negative.text-white.text-caption.q-pa-sm
+                        | can not load image
             q-file(v-model="file" label="Upload PDF")
               template(v-slot:prepend)
                 q-icon(name="attach_file")
@@ -385,7 +565,7 @@ q-dialog(
                 q-select.col-grow(
                   ref="treasurySymbol"
                   v-model="form.treasurySymbol"
-                  label="Treasury"
+                  label="DAO"
                   :options="getTreasurySymbols"
                   :rules="[rules.required]"
                 )
@@ -447,13 +627,17 @@ q-dialog(
               | , but you can change them if you want.
               .q-mt-sm.raw.flex.gap
                 q-input.col-grow(
-                  v-model="form.defaultLabels[0]"
+                  ref="op_a_1"
+                  v-model="form.optionsLabels[0]"
                   label="option 1"
+                  :rules="[rules.required]"
                 )
                 q-input.col-grow(
-                  v-model="form.defaultLabels[1]"
+                  ref="op_a_2"
+                  v-model="form.optionsLabels[1]"
                   label="option 2"
-                )
+                  :rules="[rules.required]"
+                ) 
             div(:class="typeOfBallot == ballotTypes[1] ? '' : 'hidden'")
               | This kind of ballot is the same as the binary one but has three options to vote for.
               | By default we use the words
@@ -465,17 +649,23 @@ q-dialog(
               | , but you can change them if you want.
               .q-mt-sm.raw.flex.gap
                 q-input.col-grow(
-                  v-model="form.defaultLabels[0]"
+                  ref="op_b_1"
+                  v-model="form.optionsLabels[0]"
                   label="option 1"
+                  :rules="[rules.required]"
                 )
                 q-input.col-grow(
-                  v-model="form.defaultLabels[1]"
+                  ref="op_b_2"
+                  v-model="form.optionsLabels[1]"
                   label="option 2"
+                  :rules="[rules.required]"
                 )
                 q-input.col-grow(
-                  v-model="form.defaultLabels[2]"
+                  ref="op_b_3"
+                  v-model="form.optionsLabels[2]"
                   label="option 3"
-                )
+                  :rules="[rules.required]"
+                )  
             div(:class="typeOfBallot == ballotTypes[2] ? '' : 'hidden'")
               | Multiple option ballots are completely configurable.
               | You can define a list of several options to vote for, with human readability names,
@@ -483,28 +673,45 @@ q-dialog(
               .q-mt-sm.flex.row.gap
                 .col.flex.column.options-left
                   .flex.row.items-center.gap.options-left__header
-                    q-input.col-grow( v-model="form.newOptionLabel" label="new option" bottom-slots )
+                    q-input.col-grow(ref="newOptionInput" v-model="form.newOptionLabel" label="new option" bottom-slots :rules="[isNewOptionRequired]" @update:model-value="rules.setActive(false)")
                       template(v-slot:append)
                         q-btn(no-caps color="primary" icon="add" label="add" @click="addOption()")
                   .flex.column.q-pa-md.options-left__options-list
                     .flex.row.items-center.options-left__option(v-for="(coso,index) in form.optionsLabels")
-                      q-input.col-grow.options-left__option-label(:dense="true" bottom-slots v-model="form.optionsLabels[index]" )
+                      q-input.col-grow.options-left__option-label(:dense="true" bottom-slots v-model="form.optionsLabels[index]" @update:model-value="rules.setActive(false)")
                         template(v-slot:append)
                           q-icon.cursor-pointer(name="close" @click="deleteOption(index)")
-                  .flex.row.justify-between
-                    q-checkbox(v-model="form.onlyOneOption" v-if="form.onlyOneOption") Voters can only choose one option
-                    div
+                    q-select.options-labels(
+                      dense
+                      readonly
+                      hide-dropdown-icon
+                      standout
+                      ref="optionsLabels"
+                      v-model="form.optionsLabels"
+                      multiple
+                      :rules="[rules.minimumOptions(2), rules.arrayWithUniqueItems]"
+                    )
+                      template(v-slot:prepend)
+                        .text-body2.text-weight-bolder options:
+                  .flex.row.justify-end.gap-sm
+                    q-checkbox(v-model="onlyOneOption" v-if="onlyOneOption") Voters can only choose one option
+                    div.flex-grow
+                    q-btn(no-caps color="primary" icon="list" label="Reset" @click="setDefaultOptions(3)")
                     q-btn(no-caps color="primary" icon="delete_sweep" label="Clean" @click="cleanOptions()")
-                .col.flex.column.options-right(v-if="!form.onlyOneOption")
-                  q-checkbox(v-model="form.onlyOneOption") Voters can only choose one option
+                .col.flex.column.options-right(v-if="!onlyOneOption")
+                  q-checkbox(v-model="onlyOneOption") Voters can only choose one option
                   div.q-mt-sm
                     | You are allowing voters to check several options (or none) in the same vote. Now you should set the maximum and minimum.
                     br
                     | For example, if you need to select two members from five options, your max and min should both equal 2.
                     | However, if you want to know what colors people like from a list, you will put the min at zero and the max high enough to select them all.
                   .flex.row.q-mt-sm.options-right__howmany
-                    q-input.col-auto.options-right__howmany-min( v-model="form.minOptions" label="minimun" )
-                    q-input.col-auto.options-right__howmany-max( v-model="form.maxOptions" label="maximun" )
+                    q-input.col-auto.options-right__howmany-min(ref="minimun" v-model="form.minOptions" label="minimun"
+                      :rules="[rules.required, rules.integer, rules.isNatural, rules.lowerOrEqualThan(form.maxOptions)]"
+                    )
+                    q-input.col-auto.options-right__howmany-max(ref="maximun" v-model="form.maxOptions" label="maximun"
+                      :rules="[rules.required, rules.integer, rules.positiveInteger, rules.greaterOrEqualThan(form.minOptions), rules.lowerOrEqualThan(form.optionsLabels.length)]"
+                    )
         q-step(
           :name="4"
           title="Open Voting"
@@ -512,14 +719,14 @@ q-dialog(
           :done="step > 4"
         )      
           p You can open this ballot for voting right away or you can create the ballot and skip this step for later.
-          q-checkbox(v-model="form.openForVoting") Open for voting right away
+          q-checkbox(v-model="openForVoting") Open for voting right away
           q-input(
             ref="endDate"
             v-model="form.endDate"
             label="End date"
-            :disable="!form.openForVoting"
+            :disable="!openForVoting"
+            :rules="[rules.required, rules.dateFuture(Date.now())]"
           )
-            // :rules="[rules.required, rules.dateFuture(Date.now())]"
             template(v-slot:append)
               q-icon.cursor-pointer(name="event" color="primary")
                 q-popup-proxy(ref="qDateProxy" anchor="bottom left" self="top right" transition-show="scale" transition-hide="scale")
@@ -545,10 +752,10 @@ q-dialog(
               ballot-list-item(
                 :ballot="ballot"
                 :displayWinner="displayWinner"
-                :isBallotOpened="false"
-                :votingHasBegun="false"
+                :isBallotOpened="true"
+                :votingHasBegun="true"
                 :getStartTime="getStartTime()"
-                :getEndTime="getEndTime()"
+                :getEndTime="form.endDate"
                 :getLoser="getLoser"
                 :ballotContentImg="ballotContentImg"
               )
@@ -556,310 +763,42 @@ q-dialog(
               .q-mt-sm
                 b title:
                 br
-                span Título del propsal
+                span {{form.title}}
               .q-mt-sm
                 b description:
                 br
-                span Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+                span {{form.description}}
               .q-mt-sm
                 b DAO:&nbsp;
-                span Telos Governance Token
+                span {{form.treasurySymbol.label}}
               .q-mt-sm
-                b options:
-                br
-                ul.q-mt-xs
-                  li Yes
-                  li No
-                  li Abstain
-                span Voters only can choose one option
+                .flex.row.gap
+                  .col.flex.column
+                    b options:
+                    ul.q-mt-xs
+                      li(v-for="(option,index) in form.optionsLabels") {{option}}
+                  .col.flex.column
+                    br
+                    span(v-if="onlyOneOption") Voters only can choose one option
+                    span(v-if="!onlyOneOption") Voters can choose from {{form.minOptions}} to {{form.maxOptions}} options
               .q-mt-sm
                 b open:&nbsp;
-                span this ballot will be open from now until {{moment(getEndTime()).format("MMMM Do YYYY")}}
+                span(v-if="openForVoting") this ballot will be open from now until {{moment(form.endDate).format("MMMM Do YYYY")}}
+                span(v-if="!openForVoting") this ballot will not open immediately and must be oppened manually in the future
         template(v-slot:navigation)
           q-stepper-navigation.flex
-            q-btn.q-ml-sm(color="primary" label="Back"     flat v-if="step > 1" @click="$refs.stepper.previous()")
-            .col-grow
             q-btn.q-ml-sm(color="primary" label="Cancel"   flat @click="onCancel()")
-            q-btn.q-ml-sm(color="primary" label="Continue" v-if="step !== 5" @click="$refs.stepper.next()")
+            .col-grow
+            q-btn.q-ml-sm(color="primary" label="Back"     flat v-if="step > 1" @click="$refs.stepper.previous()")
+            q-btn.q-ml-sm(color="primary" label="Continue" v-if="step !== 5" @click="nextStep()")
             q-btn.q-ml-sm(color="primary" label="Finish"   v-if="step === 5" @click="onAddBallot()")
 
-
-
-
-
-
-//
-      q-input(
-        ref="title"
-        v-model="form.title"
-        label="Title"
-        :rules="[rules.required]"
-      )
-      q-input(
-        ref="description"
-        v-model="form.description"
-        label="Description"
-        type="textarea"
-        :rules="[rules.required]"
-      )
-      q-input(
-        class="q-mb-md"
-        ref="img"
-        v-model="form.imageUrl"
-        label="Image URL"
-        placeholder="https://..."
-        hint="Upload an image and paste the url here to include it in your ballot."
-        :rules="[rules.required]"
-      )
-      q-file(v-model="file" label="Upload PDF")
-        template(v-slot:prepend)
-          q-icon(name="attach_file")
-      .row
-        q-radio(
-          v-model="form.config"
-          label="Simple Yes or No"
-          val="votestake"
-          hint="A simple ballot with only two options to vote for. By default, the words 'Yes' and 'No' are used but you can change them."
-        )
-        q-radio(
-          v-model="form.config"
-          label="Yes/No/Abstain"
-          val="asddd"
-        )
-        q-radio(
-          v-model="form.config"
-          label="Multiple option"
-          val="voteliquid"
-        )
-      .row A simple ballot with only two options to vote for. By default, the words 'Yes' and 'No' are used but you can change them.
-        
-      q-input(
-        ref="endDate"
-        v-model="form.endDate"
-        label="End date"
-        :rules="[rules.required, rules.dateFuture(Date.now())]"
-      )
-        template(v-slot:append)
-          q-icon.cursor-pointer(name="event")
-            q-popup-proxy(ref="qDateProxy" transition-show="scale" transition-hide="scale")
-              q-date(
-                v-model="form.endDate"
-                @input="() => $refs.qDateProxy.hide()"
-                mask="YYYY-MM-DD HH:mm"
-              )
-          q-icon.cursor-pointer(name="access_time")
-            q-popup-proxy(ref="qDateProxy" transition-show="scale" transition-hide="scale")
-              q-time(
-                v-model="form.endDate"
-                @input="() => $refs.qDateProxy.hide()"
-                mask="YYYY-MM-DD HH:mm"
-              )
-    q-card-actions(align="right")
-      q-btn(
-        flat
-        :label="$t('common.buttons.cancel')"
-        @click="onCancel()"
-      )
-      q-btn(
-        color="primary"
-        :label="$t('common.buttons.create')"
-        :loading="submitting"
-        @click="openConfirmation()"
-      )
-    q-dialog(
-      v-model="prompt"
-      persistent
-    )
-      q-card(
-        style="min-width: 350px"
-      )
-        q-card-section.row.items-center
-          span.q-ml-sm(
-            v-if="available"
-          ) There will be a {{fee}} fee for creating a ballot.
-          span.q-ml-sm(
-            v-else
-          ) {{ "Insufficient balance to create a ballot." }}
-        q-card-actions.text-primary(
-          align="right"
-        )
-          q-btn(
-            flat
-            label="Cancel"
-            v-close-popup
-          )
-          q-btn(
-            v-if="available"
-            flat
-            label="Accept"
-            v-close-popup
-            @click="onAddBallot()"
-          )
-
-
-    q-card-section.bg-primary.text-white
-      .text-h6 Create a ballot
-
-    q-card-section
-      q-input(
-        ref="title"
-        v-model="form.title"
-        label="Title"
-        :rules="[rules.required]"
-      )
-      q-select(
-        ref="category"
-        v-model="form.category"
-        label="Category"
-        :options="categoryOptions"
-        emit-value
-        map-options
-        :rules="[rules.required]"
-      )
-      q-select(
-        ref="votingMethod"
-        v-model="form.votingMethod"
-        label="Voting method"
-        :options="votingMethodOptions"
-        emit-value
-        map-options
-        :rules="[rules.required]"
-      )
-      q-input(
-        ref="description"
-        v-model="form.description"
-        label="Description"
-        type="textarea"
-        :rules="[rules.required]"
-      )
-      q-input(
-        class="q-mb-md"
-        ref="img"
-        v-model="form.imageUrl"
-        label="Image URL"
-        placeholder="https://..."
-        hint="Upload an image and paste the url here to include it in your ballot."
-        :rules="[rules.required]"
-      )
-      q-file(v-model="file" label="Upload PDF")
-        template(v-slot:prepend)
-          q-icon(name="attach_file")
-      q-select(
-        ref="treasurySymbol"
-        v-model="form.treasurySymbol"
-        label="Treasury"
-        :options="getTreasurySymbols"
-        :rules="[rules.required]"
-      )
-      q-select(
-        ref="initialOptions"
-        v-model="form.initialOptions"
-        label="Options"
-        use-input
-        use-chips
-        multiple
-        hide-dropdown-icon
-        input-debounce="0"
-        @new-value="addBallotOption"
-        :rules="[rules.required, rules.minimumOptions(2)]"
-      )
-      .row
-        q-input.col-6(
-          type="number"
-          ref="minOptions"
-          v-model="form.minOptions"
-          label="Min options"
-          :rules="[rules.required, rules.integer, rules.positiveInteger]"
-        )
-        q-input.col-6(
-          type="number"
-          ref="maxOptions"
-          v-model="form.maxOptions"
-          label="Max options"
-          :rules="[rules.required, rules.integer, rules.positiveInteger, rules.greaterOrEqualThan(form.minOptions), rules.greaterOrEqualThan(2)]"
-        )
-      .row(
-        v-if="configEnable"
-      )
-        q-radio(
-          v-model="form.config"
-          label="Stakeble"
-          val="votestake"
-        )
-        q-radio(
-          v-model="form.config"
-          label="Liquid"
-          val="voteliquid"
-        )
-        q-radio(
-        v-model="form.config"
-        label="Both"
-        val="both"
-        )
-      q-input(
-        ref="endDate"
-        v-model="form.endDate"
-        label="End date"
-        :rules="[rules.required, rules.dateFuture(Date.now())]"
-      )
-        template(v-slot:append)
-          q-icon.cursor-pointer(name="event")
-            q-popup-proxy(ref="qDateProxy" transition-show="scale" transition-hide="scale")
-              q-date(
-                v-model="form.endDate"
-                @input="() => $refs.qDateProxy.hide()"
-                mask="YYYY-MM-DD HH:mm"
-              )
-          q-icon.cursor-pointer(name="access_time")
-            q-popup-proxy(ref="qDateProxy" transition-show="scale" transition-hide="scale")
-              q-time(
-                v-model="form.endDate"
-                @input="() => $refs.qDateProxy.hide()"
-                mask="YYYY-MM-DD HH:mm"
-              )
-    q-card-actions(align="right")
-      q-btn(
-        flat
-        :label="$t('common.buttons.cancel')"
-        @click="onCancel()"
-      )
-      q-btn(
-        color="primary"
-        :label="$t('common.buttons.create')"
-        :loading="submitting"
-        @click="openConfirmation()"
-      )
-    q-dialog(
-      v-model="prompt"
-      persistent
-    )
-      q-card(
-        style="min-width: 350px"
-      )
-        q-card-section.row.items-center
-          span.q-ml-sm(
-            v-if="available"
-          ) There will be a {{fee}} fee for creating a ballot.
-          span.q-ml-sm(
-            v-else
-          ) {{ "Insufficient balance to create a ballot." }}
-        q-card-actions.text-primary(
-          align="right"
-        )
-          q-btn(
-            flat
-            label="Cancel"
-            v-close-popup
-          )
-          q-btn(
-            v-if="available"
-            flat
-            label="Accept"
-            v-close-popup
-            @click="onAddBallot()"
-          )
 </template>
-<style scoped lang="sass">
+<style lang="sass">
+.q-field--standout.q-field--highlighted .q-field__control
+  background: #{$negative} !important  
+.q-stepper.ballot-creation
+  min-height:80vh
 .q-stepper--horizontal
   display: flex
   flex-direction: column

--- a/src/pages/trails/ballots/components/BallotListItem.vue
+++ b/src/pages/trails/ballots/components/BallotListItem.vue
@@ -14,8 +14,7 @@ export default {
     votingHasBegun: { type: Boolean, required: true },
     getStartTime: { type: Number, required: true },
     getEndTime: { type: Number, required: true },
-    getLoser: { type: Function, required: true },
-    ballotContentImg: { type: Function, required: true },
+    getLoser: { type: Function, required: true }
   },
   data() {
     return {
@@ -97,8 +96,8 @@ export default {
 div
   q-card(:class="ballot.status === 'voting' && isBallotOpened ? '' : 'poll-ended'").poll-item
     q-card-section().card-img-wrapper
-      template(v-if="ballotContentImg(ballot)")
-        q-img(:src="ballotContentImg(ballot)").poll-item-image-wrapper
+      template(v-if="ballot.imageUrl")
+        q-img(:src="ballot.imageUrl").poll-item-image-wrapper
           template(v-slot:error)
             q-icon(size="lg" name="far fa-image")
       template(v-else)
@@ -157,7 +156,7 @@ div
           div.statics-section-wrapper
             div.statics-section-item(v-if="ballot.total_voters > 0")
               span.text-weight-bold {{ getPercentofTotal(getWinner) }}%&nbsp
-              span.opacity06  {{ getWinner.key.toUpperCase() }} {{ getLoser.key ? ` lead over ${getLoser.key.toUpperCase()}` : ` lead over others` }}
+              span.opacity06  {{ getWinner.displayText }} {{ getLoser.displayText ? ` lead over ${getLoser.displayText}` : ` lead over others` }}
             div.statics-section-item(v-else)
               span  {{ getWinner }}
             div.bar-custom-separator.text-section-separator
@@ -174,7 +173,7 @@ div
       div.text-section.column
         div.statics-section-item(v-if="ballot.total_voters > 0")
           span.text-weight-bold {{ getPercentofTotal(getWinner) }}%&nbsp
-          span.opacity06  {{ getWinner.key.toUpperCase() }} {{ getLoser.key ? ` lead over ${getLoser.key.toUpperCase()}` : ` lead over others` }}
+          span.opacity06  {{ getWinner.displayText }} {{ getLoser.displayText ? ` lead over ${getLoser.displayText}` : ` lead over others` }}
         div.statics-section-item(v-else)
           span  {{ getWinner }}
         div.statics-section-item

--- a/src/pages/trails/ballots/components/BallotListItem.vue
+++ b/src/pages/trails/ballots/components/BallotListItem.vue
@@ -11,7 +11,7 @@ export default {
     ballot: { type: Object, required: true },
     displayWinner: { type: Function, required: true },
     isBallotOpened: { type: Boolean, required: true },
-    votingHasBegun: { type: Boolean, required: true },
+    startTimeHasPassed: { type: Boolean, required: true },
     getStartTime: { type: Number, required: true },
     getEndTime: { type: Number, required: true },
     getLoser: { type: Function, required: true }
@@ -117,7 +117,7 @@ div
       :ballot="ballot"
       :isBallotOpened="isBallotOpened"
       :getEndTime="getEndTime"
-      :votingHasBegun="votingHasBegun"
+      :startTimeHasPassed="startTimeHasPassed"
       :getStartTime="getStartTime"
     )
 

--- a/src/pages/trails/ballots/components/BallotOpenVotingDialog.vue
+++ b/src/pages/trails/ballots/components/BallotOpenVotingDialog.vue
@@ -1,0 +1,95 @@
+<script>
+import { mapActions } from 'vuex';
+import moment from 'moment';
+import { validation }         from '~/mixins/validation';
+
+export default {
+  name: 'BallotOpenVotingDialog',
+  props: {
+    show: { type: Boolean, required: true },
+    ballot: { type: Object, required: true }
+  },
+  mixins: [validation],
+  emits: ['close', 'done'],
+  data() {
+    return {
+      loading: false,
+      form: {
+        endTime: moment(new Date()).add(20, 'days').format('YYYY-MM-DD HH:mm'),
+      }
+    };
+  },
+  watch: {
+    'form.endTime'() {
+      if (!this.$refs.qDateProxy1 || this.$refs.qDateProxy2) return;
+      this.$refs.qDateProxy1.hide();
+      this.$refs.qDateProxy2.hide();
+    },
+    show() {
+      if (this.show) {
+        this.loading = false;
+        this.form.endTime = moment(new Date()).add(20, 'days').format('YYYY-MM-DD HH:mm');
+      }
+    }
+  },
+  methods: {
+    ...mapActions('trails', ['openBallotForVoting']),
+    async onConfirm() {
+      this.rules.setActive(true);
+      let ok = await this.validate(this.form);
+      if (!ok) return;
+      this.loading = true;
+      await this.openBallotForVoting({
+        ballot_name:this.ballot.ballot_name,
+        endTime: this.form.endTime
+      });
+      this.$emit('done');
+      this.loading = false;
+    },
+  },
+};
+</script>
+
+<template lang="pug">
+q-dialog(
+  v-model="show"
+)
+  q-card
+    q-card-section
+      .text-h6 {{ $t('pages.trails.ballots.openBallotHeader') }}
+    q-card-section
+      q-input(
+        ref="endTime"
+        v-model="form.endTime"
+        label="End date"
+        :rules="[rules.required, rules.dateFuture(Date.now())]"
+      )
+        template(v-slot:append)
+          q-icon.cursor-pointer(name="event" color="primary")
+            q-popup-proxy(ref="qDateProxy1" anchor="bottom left" self="center right" transition-show="scale" transition-hide="scale")
+              q-date(
+                v-model="form.endTime"
+                mask="YYYY-MM-DD HH:mm"
+              )
+          q-icon.cursor-pointer(name="access_time" color="primary")
+            q-popup-proxy(ref="qDateProxy2" anchor="bottom left" self="center right" transition-show="scale" transition-hide="scale")
+              q-time(
+                v-model="form.endTime"
+                mask="YYYY-MM-DD HH:mm"
+              )
+    q-card-actions(
+      align="right"
+    )
+      q-btn(
+        flat
+        :label="$t('common.buttons.cancel')"
+        @click="$emit('close')"
+      )
+      q-btn(
+        color="primary"
+        :label="$t('common.buttons.confirm')"
+        @click="onConfirm"
+        :loading="loading"
+      )
+
+</template>

--- a/src/pages/trails/ballots/components/BallotStatus.vue
+++ b/src/pages/trails/ballots/components/BallotStatus.vue
@@ -7,7 +7,7 @@ export default {
   props: {
     ballot: { type: Object, required: true },
     isBallotOpened: { type: Boolean, required: true },
-    votingHasBegun: { type: Boolean, required: true },
+    startTimeHasPassed: { type: Boolean, required: true },
     getStartTime: { type: Number, required: true },
     getEndTime: { type: Number, required: true },
   },
@@ -25,16 +25,26 @@ div.left-tag.cursor-default
     div.status-frame-title Time left
     countdown(:endtime="getEndTime")
 
-  template(v-else-if="ballot.status === 'voting' && !votingHasBegun")
+  template(v-else-if="ballot.status === 'voting' && !startTimeHasPassed")
     div.status-frame-title Voting begins in
     countdown(:endtime="getStartTime")
 
+  template(v-else-if="ballot.status === 'setup'")
+    div.status-frame-title Status
+    div Setup
+
   template(v-else)
     div.status-frame-title Status
-    span(v-if="ballot.status === 'setup'") Setup
-    span(v-else) Proposal ended
-  div.status-frame-title.time {{Date.now() > getEndTime ? "Ended" : "Ends"}}
-  div {{moment(getEndTime).format("MMMM Do YYYY")}}
+    span Proposal ended
+
+
+  template(v-if="ballot.status === 'setup'")
+    div.status-frame-title.time draft
+    div not started yet
+
+  template(v-else)
+    div.status-frame-title.time {{Date.now() > getEndTime ? "Ended" : "Ends"}}
+    div {{moment(getEndTime).format("MMMM Do YYYY")}}
 
 </template>
 

--- a/src/pages/trails/ballots/list/BallotsList.vue
+++ b/src/pages/trails/ballots/list/BallotsList.vue
@@ -83,14 +83,14 @@ export default {
       }
     },
     openBallotForm() {
-      console.log("openBallotForm()");
+      console.log('openBallotForm()');
       this.show = true;
     },
     closeBallot() {
       this.$router.go(-1);
     },
     openBallot(ballot) {
-      console.log("openBallot()", [ballot]);
+      console.log('openBallot()', [ballot]);
       this.timeAtMount = Date.now();
       this.$router.push(
         `/trails/${

--- a/src/pages/trails/ballots/list/BallotsList.vue
+++ b/src/pages/trails/ballots/list/BallotsList.vue
@@ -83,12 +83,14 @@ export default {
       }
     },
     openBallotForm() {
+      console.log("openBallotForm()");
       this.show = true;
     },
     closeBallot() {
       this.$router.go(-1);
     },
     openBallot(ballot) {
+      console.log("openBallot()", [ballot]);
       this.timeAtMount = Date.now();
       this.$router.push(
         `/trails/${
@@ -141,15 +143,15 @@ export default {
     },
     updateTreasury(newTreasury) {
       this.treasury = newTreasury;
-      this.$refs.infiniteScroll.resume();
+      if (this.$refs.infiniteScroll) this.$refs.infiniteScroll.resume();
     },
     updateStatuses(newStatuses) {
       this.statuses = newStatuses;
-      this.$refs.infiniteScroll.resume();
+      if (this.$refs.infiniteScroll) this.$refs.infiniteScroll.resume();
     },
     updateCategories(newCategories) {
       this.categories = newCategories;
-      this.$refs.infiniteScroll.resume();
+      if (this.$refs.infiniteScroll) this.$refs.infiniteScroll.resume();
     },
     filterBallots(ballots) {
       const ballotFilteredByStatuses = ballots.filter((b) => {

--- a/src/pages/trails/ballots/list/BallotsList.vue
+++ b/src/pages/trails/ballots/list/BallotsList.vue
@@ -337,6 +337,8 @@ q-page(v-if="!renderComponent")
       //- q-btn(v-close-popup color="secondary").float-right Close
 </template>
 <style lang="sass" scoped>
+main.q-page
+  padding-top: 40px
 .link
   text-decoration: none
 .banner

--- a/src/pages/trails/ballots/list/BallotsList.vue
+++ b/src/pages/trails/ballots/list/BallotsList.vue
@@ -127,7 +127,7 @@ export default {
       });
       return winner;
     },
-    votingHasBegun(ballot) {
+    startTimeHasPassed(ballot) {
       let startTime = new Date(ballot.begin_time).getTime();
       let isStarted = startTime < Date.now();
       return isStarted;
@@ -169,7 +169,7 @@ export default {
             return (
               this.statuses.includes(b.status) ||
               (!this.isBallotOpened(b) &&
-                this.votingHasBegun(b) &&
+                this.startTimeHasPassed(b) &&
                 b.status === 'voting')
             );
           } else if (this.statuses.includes('not started')) {
@@ -299,7 +299,7 @@ q-page(v-if="!renderComponent")
           :ballot="ballot"
           :displayWinner="displayWinner"
           :isBallotOpened="isBallotOpened(ballot)"
-          :votingHasBegun="votingHasBegun(ballot)"
+          :startTimeHasPassed="startTimeHasPassed(ballot)"
           :getStartTime="getStartTime(ballot)"
           :getEndTime="getEndTime(ballot)"
           :getLoser="getLoser"
@@ -320,7 +320,7 @@ q-page(v-if="!renderComponent")
     ballot-view(
       :isBallotOpened="isBallotOpened"
       :displayWinner="displayWinner"
-      :votingHasBegun="votingHasBegun"
+      :startTimeHasPassed="startTimeHasPassed"
       :getStartTime="getStartTime"
       :getEndTime="getEndTime"
       :getLoser="getLoser"

--- a/src/pages/trails/ballots/list/BallotsList.vue
+++ b/src/pages/trails/ballots/list/BallotsList.vue
@@ -241,13 +241,6 @@ export default {
       this.limit = 100;
       this.sortMode = option;
     },
-    ballotContentImg(ballot) {
-      try {
-        return JSON.parse(ballot.content).imageUrl;
-      } catch (error) {
-        return null;
-      }
-    },
     updateCards(params) {
       this.treasury = params.treasury;
       this.statuses = params.tatus;
@@ -310,7 +303,6 @@ q-page(v-if="!renderComponent")
           :getStartTime="getStartTime(ballot)"
           :getEndTime="getEndTime(ballot)"
           :getLoser="getLoser"
-          :ballotContentImg="ballotContentImg"
         )
       p.text-weight-bold(
         style="text-align: center"
@@ -332,7 +324,6 @@ q-page(v-if="!renderComponent")
       :getStartTime="getStartTime"
       :getEndTime="getEndTime"
       :getLoser="getLoser"
-      :ballotContentImg="ballotContentImg"
     )
       //- q-btn(v-close-popup color="secondary").float-right Close
 </template>

--- a/src/pages/trails/ballots/view/BallotView.vue
+++ b/src/pages/trails/ballots/view/BallotView.vue
@@ -15,7 +15,7 @@ export default {
   props: {
     isBallotOpened: { type: Function, required: true },
     displayWinner: { type: Function, required: true },
-    votingHasBegun: { type: Function, required: true },
+    startTimeHasPassed: { type: Function, required: true },
     getStartTime: { type: Function, required: true },
     getEndTime: { type: Function, required: true },
     getLoser: { type: Function, required: true },
@@ -168,6 +168,9 @@ export default {
       'fetchTreasuriesForUser',
       'resetUserVotes'
     ]),
+    debug() {
+        console.log(this.ballot);
+    },
     openUrl(url) {
       window.open(`${process.env.BLOCKCHAIN_EXPLORER}/account/${url}`);
     },
@@ -322,7 +325,7 @@ export default {
 </script>
 
 <template lang="pug">
-.row.bg-white.justify-between.popup-wrapper(@scroll="updatePopupScroll")
+.row.bg-white.justify-between.popup-wrapper(@scroll="updatePopupScroll" @click="debug")
         template(v-if="!loading && ballot")
             .col-xs.col-sm-auto.popup-left-col-wrapper(style="min-width: 268px;" v-if="showDetails")
                 q-card(
@@ -369,7 +372,7 @@ export default {
                             :ballot="ballot"
                             :isBallotOpened="isBallotOpened(ballot)"
                             :getEndTime="getEndTime(ballot)"
-                            :votingHasBegun="votingHasBegun(ballot)"
+                            :startTimeHasPassed="startTimeHasPassed(ballot)"
                             :getStartTime="getStartTime(ballot)"
                             )
 

--- a/src/pages/trails/ballots/view/BallotView.vue
+++ b/src/pages/trails/ballots/view/BallotView.vue
@@ -9,13 +9,6 @@ const FROM_BOTH = 'both';
 const FROM_LIQUID = 'liquid';
 const FROM_STAKE = 'stake';
 
-
-const regex = new RegExp(/Qm[1-9A-HJ-NP-Za-km-z]{44}(\/.*)?/, 'm'); // ipfs hash detection, detects CIDv0 46 character strings starting with 'Qm'
-const regexWithUrl = new RegExp(
-  /https?\:\/\/.*Qm[1-9A-HJ-NP-Za-km-z]{44}(\/.*)?/,
-  'm'
-); // ipfs hash detection, detects CIDv0 46 character strings starting with 'Qm'
-
 export default {
   name: 'BallotView',
   components: { BallotStatus, BallotChip, Btn },
@@ -26,7 +19,6 @@ export default {
     getStartTime: { type: Function, required: true },
     getEndTime: { type: Function, required: true },
     getLoser: { type: Function, required: true },
-    ballotContentImg: { type: Function, required: true },
   },
   data() {
     return {
@@ -42,6 +34,7 @@ export default {
   },
   async mounted() {
     this.getLoggedUserVotes(this.$route.params.id);
+    this.fetchTreasuriesForUser(this.account);
     await this.fetchBallot(this.$route.params.id);
     window.addEventListener('scroll', this.updateScroll);
     this.loading = false;
@@ -74,24 +67,6 @@ export default {
       });
       return this.ballot.options[winner];
     },
-    ballotDescription() {
-      if (this.iframeUrl) {
-        return this.ballot.description
-          .replace(regexWithUrl, '')
-          .replace(regex, '');
-      }
-
-      const descriptionWithLinks = this.findLinks(this.ballot.description);
-
-      return descriptionWithLinks;
-    },
-    ballotContent() {
-      if (this.ballot.content.match(regex)) {
-        return this.ballot.content.replace(regexWithUrl, '').replace(regex, '');
-      }
-
-      return this.ballot.content;
-    },
     ballotContentOptionData() {
       try {
         const data = Object.values(JSON.parse(this.ballot.content).optionData);
@@ -99,38 +74,6 @@ export default {
       } catch (error) {
         return null;
       }
-    },
-    iframeUrl() {
-      let content = this.ballot.content;
-      let file_path = null;
-
-      // catch parse possible errors
-      try {
-        content = JSON.parse(this.ballot.content);
-      } catch (e) {
-        console.error(e)
-      }
-      try {
-        file_path = regex.exec(this.ballot.description);
-      } catch (e) {
-        console.error(e)
-      }
-
-      if (Array.isArray(file_path)) {
-        const r = 'https://ipfs.io/ipfs/' + file_path[0];
-        return r;
-      } else if (typeof content === 'object') {
-        // prioritize content urls over image urls
-        const r =
-          content.contentUrl ||
-          (content.contentUrls || [])[0] ||
-          content.imageUrl ||
-          (content.imageUrls || [])[0];
-        return r;
-      } else {
-        return false;
-      }
-      // https://api.ipfsbrowser.com/ipfs/get.php?hash=QmS6QwbGDde7cdyvWfUSX5PPWrFkiumqTHouBV3jYhPXme
     },
     getVariants() {
       let newArr = [];
@@ -210,6 +153,11 @@ export default {
         }
     },
   },
+  watch: {
+    account: async function (account) {
+      this.fetchTreasuriesForUser(account);
+    },
+  },
   methods: {
     ...mapActions('trails', [
       'fetchBallot',
@@ -219,7 +167,6 @@ export default {
       'fetchUserVotesForThisBallot',
       'fetchTreasuriesForUser',
       'resetUserVotes'
-
     ]),
     openUrl(url) {
       window.open(`${process.env.BLOCKCHAIN_EXPLORER}/account/${url}`);
@@ -390,7 +337,7 @@ export default {
                             span Go Back
                     q-card-section.body-info
                         div(v-for="option in getVariants")
-                            div.text-weight-bold.variant-name {{ option.key }}
+                            div.text-weight-bold.variant-name {{ option.displayText }}
                             div.list-voters(v-for="(i, idx) in getVoters(option.key)" :key="idx")
                                 span {{ i.voter }}
                                 span.text-weight-bold {{ getPercentOfNumber(i.value, option.value) }}
@@ -404,8 +351,8 @@ export default {
                 )
                     q-card-section.card-img-section
                         div.card-img-wrapper
-                            template(v-if="ballotContentImg(ballot)")
-                                q-img(:src="ballotContentImg(ballot)").poll-item-image-wrapper
+                            template(v-if="ballot.imageUrl")
+                                q-img(:src="ballot.imageUrl").poll-item-image-wrapper
                                     template(v-slot:error)
                                         q-icon(size="lg" name="far fa-image")
                             template(v-else)
@@ -446,7 +393,7 @@ export default {
                                             @click.native="toggleOption(option.key)"
                                             )
                                                 div.checkbox-text.row.space-between
-                                                    div {{ option.key }}
+                                                    div {{ option.displayText }}
                                                     div(v-if="getPartOfTotal(option)") {{ getPartOfTotalPercent(option) }}%&nbsp
                                     div.linear-progress(v-if="displayWinner(ballot)")
                                         q-linear-progress(rounded size="6px" :value="getPartOfTotal(option)" color="$primary")
@@ -522,7 +469,7 @@ export default {
                     q-card-section.description-section-wrapper
                         div.description-section
                             div.description-section-title(:class="iframeUrl ? `q-pb-md` : `q-pb-xl q-mb-lg`")
-                                p(v-html="ballotDescription")
+                                p(v-html="ballot.readableDescription")
                             div(
                             v-if="ballotContentOptionData && ballotContentOptionData[0] && ballotContentOptionData[0].hasOwnProperty('imageUrl')"
                             ).q-pb-md.ballot-content-carousel
@@ -562,8 +509,8 @@ export default {
                             iframe(
                             height="100%"
                             width="100%"
-                            v-if="iframeUrl"
-                            :src="iframeUrl"
+                            v-if="ballot.iframeUrl"
+                            :src="ballot.iframeUrl"
                             ).kv-preview-data.file-preview-pdf.file-zoom-detail.shadow-1
                             div(v-else).text-center
                                 img(src="/statics/app-icons/no-pdf.svg" style="width: 60px;")
@@ -588,7 +535,7 @@ export default {
                                                 @click.native="toggleOption(option.key)"
                                                 )
                                                     div.checkbox-text.row.space-between
-                                                        div {{ option.key }}
+                                                        div {{ option.displayText }}
                                                         div(v-if="getPartOfTotal(option)") {{ getPartOfTotalPercent(option) }}%&nbsp
                                         div.linear-progress(v-if="displayWinner(ballot)")
                                             q-linear-progress(rounded size="6px" :value="getPartOfTotal(option)" color="$primary")
@@ -613,7 +560,7 @@ export default {
                                 div.text-section.column
                                     div.statics-section-item(v-if="ballot.total_voters > 0")
                                         span.text-weight-bold {{ getPercentofTotal(getWinner) }}%&nbsp
-                                        span.opacity06  {{ getWinner.key.toUpperCase() }} {{ getLoser.key ? ` lead over ${getLoser.key.toUpperCase()}` : ` lead over others` }}
+                                        span.opacity06  {{ getWinner.displayText }} {{ getLoser.displayText ? ` lead over ${getLoser.displayText}` : ` lead over others` }}
                                     div.statics-section-item(v-else)
                                         span  {{ getWinner }}
                                     div.statics-section-item

--- a/src/store/trails/actions.js
+++ b/src/store/trails/actions.js
@@ -55,12 +55,17 @@ export const fetchMoreBallots = async function ({ commit, state }) {
 };
 
 export const fetchTreasuriesForUser = async function ({ commit }, account) {
+
+  console.log('fetchTreasuriesForUser() ', account);
+
   const res = await this.$api.getTableRows({
     code: 'telos.decide',
     scope: account,
     table: 'voters',
     limit: 1000,
   });
+
+  console.log('fetchTreasuriesForUser() ', account, ' -> ', res);
 
   commit('setUserTreasuries', res);
   commit('updateTreasuries');

--- a/src/store/trails/actions.js
+++ b/src/store/trails/actions.js
@@ -120,6 +120,10 @@ export const fetchUserVotesForThisBallot = async function (
   commit('setBallotVotes', list);
 };
 
+export const setBallot = async function ({ commit }, ballot) {
+  commit('setBallot', ballot);
+};
+
 export const fetchBallot = async function ({ commit }, ballot) {
   const result = await this.$api.getTableRows({
     code: 'telos.decide',
@@ -248,7 +252,7 @@ export const addBallot = async function ({ commit, state, rootState }, ballot) {
     }
 
     // do the user want to open the ballot immediatelly ?
-    if (ballot.endDate) {
+    if (ballot.endDate > new Date() ) {
       actions.push({
         account: 'telos.decide',
         name: 'openvoting',

--- a/src/store/trails/actions.js
+++ b/src/store/trails/actions.js
@@ -1,4 +1,3 @@
-import slugify from 'slugify';
 import {
   supplyToAsset,
   supplyToDecimals,
@@ -155,8 +154,8 @@ export const fetchBallot = async function ({ commit }, ballot) {
 
 const createTogglebalFor = function(ballotName, text) {
   return {
-    account: "telos.decide",
-    name: "togglebal",
+    account: 'telos.decide',
+    name: 'togglebal',
     data: {
       ballot_name: ballotName,
       setting_name: text,
@@ -167,10 +166,10 @@ const createTogglebalFor = function(ballotName, text) {
 export const addBallot = async function ({ commit, state, rootState }, ballot) {
   const ballotName = ballot.title
     .toLowerCase()
-    .replace(/[^a-z12345]/gi, "")
+    .replace(/[^a-z12345]/gi, '')
     .substring(0,12);
 
-  const deposit = state.fees.find((fee) => fee.key === "ballot").value;
+  const deposit = state.fees.find((fee) => fee.key === 'ballot').value;
 
   let togglebal = {
     account: 'telos.decide',
@@ -230,15 +229,14 @@ export const addBallot = async function ({ commit, state, rootState }, ballot) {
         },
       }
     ];
-    let isBoth = false;
-    if (ballot.treasurySymbol.symbol === "VOTE") {
-      actions.splice(2, 0, createTogglebalFor(ballotName, "votestake"));
+    if (ballot.treasurySymbol.symbol === 'VOTE') {
+      actions.splice(2, 0, createTogglebalFor(ballotName, 'votestake'));
     } else if (!ballot.settings) {
-      actions.splice(2, 0, createTogglebalFor(ballotName, "voteliquid"));
+      actions.splice(2, 0, createTogglebalFor(ballotName, 'voteliquid'));
     } else if (ballot.settings && ballot.config) {
-      if (ballot.config === "both") {
-        actions.splice(2, 0, createTogglebalFor(ballotName, "votestake"));
-        actions.splice(2, 0, createTogglebalFor(ballotName, "voteliquid"));
+      if (ballot.config === 'both') {
+        actions.splice(2, 0, createTogglebalFor(ballotName, 'votestake'));
+        actions.splice(2, 0, createTogglebalFor(ballotName, 'voteliquid'));
       } else {
         togglebal.data.setting_name = ballot.config;
       }
@@ -247,8 +245,8 @@ export const addBallot = async function ({ commit, state, rootState }, ballot) {
     // do the user want to open the ballot immediatelly ?
     if (ballot.endDate) {
       actions.push({
-        account: "telos.decide",
-        name: "openvoting",
+        account: 'telos.decide',
+        name: 'openvoting',
         data: {
           ballot_name: ballotName,
           end_time: new Date(ballot.endDate).toISOString().slice(0, -5),

--- a/src/store/trails/getters.js
+++ b/src/store/trails/getters.js
@@ -12,7 +12,7 @@ export const treasuriesLoaded = ({ treasuries }) => treasuries.list.loaded;
 export const treasury = ({ treasuries }) => treasuries.view.treasury;
 export const voters = ({ ballotVoters }) => ballotVoters;
 export const userVotes = ({ userVotes }) => userVotes;
-export const userTreasury = ({ userTreasuries }) => userTreasuries?.rows;
+export const userTreasury = ({ userTreasuries }) => userTreasuries?userTreasuries.rows:[];
 export const treasuryFees = ({ fees }) =>
   fees.find((fee) => fee.key === 'treasury');
 export const ballotFees = ({ fees }) =>

--- a/src/store/trails/mutations.js
+++ b/src/store/trails/mutations.js
@@ -79,9 +79,8 @@ const enhanceBallotMetadata = (ballot) => {
     // try to extract metadata from content
     // following standard (DCMS v2) https://github.com/telosnetwork/telos-decide/blob/master/dcms-v2.md
     content = JSON.parse(ballot.content);
-
   } catch (e) {
-    console.warn('ballot.content is not a valid JSON. ballot_name:', ballot.ballot_name);
+    // this content is not parseable to JSON
   }
 
   try {

--- a/src/store/trails/state.js
+++ b/src/store/trails/state.js
@@ -11,7 +11,7 @@ export default () => ({
       },
     },
     view: {
-      ballot: null,
+      ballot: null
     },
   },
   ballotVoters: null,


### PR DESCRIPTION
# Fixes #205 and #206

## Description
This PR contains a solution for storing and displaying ballot metadata following the new standard [DCMS-v2](https://github.com/telosnetwork/telos-decide/blob/master/dcms-v2.md) while keeping support for old ballot versions. Also reflects the not-opened ballot state in all components.

## Changes
- ballots store now processes the content metadata following [DCMS-v2](https://github.com/telosnetwork/telos-decide/blob/master/dcms-v2.md) and make it ready to use everywhere.
- Ballot viewers component now extracts image, pdf, and options' metadata directly from the ballot object (no JSON process involved)
- The non-opened status for ballots is reflected in all ballot viewers
- The open ballot button is shown only for the creator

## Screenshots

![image](https://user-images.githubusercontent.com/4420760/198766282-d4b4fe53-7f22-4f03-a48a-5a8486837be9.png)
![image](https://user-images.githubusercontent.com/4420760/198767494-95e6f72a-d8b2-4d8a-84f2-6db875227305.png)
![image](https://user-images.githubusercontent.com/4420760/198763565-d9ee105a-2266-4acb-a008-d2ea05433ace.png)
