### PR TITLE
changing how we query not-started ballots

### DIFF
--- a/src/store/trails/actions.js
+++ b/src/store/trails/actions.js
@@ -16,8 +16,9 @@ export const fetchFees = async function ({ commit }) {
 // Fees
 
 // Ballots
-export const fetchMoreBallots = async function ({ commit, state }) {
-  const result = await this.$api.getTableRows({
+export const fetchMoreBallots = async function ({ commit, state }, filters) {
+
+  let query = {
     code: 'telos.decide',
     scope: 'telos.decide',
     table: 'ballots',
@@ -26,7 +27,16 @@ export const fetchMoreBallots = async function ({ commit, state }) {
     reverse: true,
     key_type: 'i64',
     lower_bound: state.ballots.list.pagination.next_key,
-  });
+  }
+
+  if (filters.includes('not_started')) {
+    query.index_position = 3;
+    query.lower_bound = 'setup';
+    query.reverse = false;
+  }
+
+  const result = await this.$api.getTableRows(query);
+
   let treasuries = { rows: [] };
   state.treasuries.list.data.forEach((t) => (treasuries[t.symbol] = t));
 

--- a/src/store/trails/mutations.js
+++ b/src/store/trails/mutations.js
@@ -48,7 +48,17 @@ export const addBallots = (state, { rows, more, next_key }) => {
   if (!more && current_count == before_count) {
     state.ballots.list.pagination.more = false;
   } else {
-    state.ballots.list.pagination.more = true;
+    if (!state.ballots.list.pagination.lastQuery) {
+      state.ballots.list.pagination.more = true;
+    } else {
+      state.ballots.list.pagination.more = false;
+    }
+  }
+
+  if (state.ballots.list.pagination.more && current_count == before_count) {
+    state.ballots.list.pagination.lastQuery = true;
+  } else {
+    state.ballots.list.pagination.lastQuery = false;
   }
 
 };

--- a/src/store/trails/state.js
+++ b/src/store/trails/state.js
@@ -8,6 +8,7 @@ export default () => ({
         next_key: '',
         limit: 250,
         more: true,
+        lastQuery: false,
       },
     },
     view: {


### PR DESCRIPTION
# Fixes #218

## Description
Not-started ballots were not shown using the `not started` filter from the ActionBar. 

## Changes made
- adjusted the way we identify a not started ballot (`ballot.type == 'setup'`)
- the query had to be changed to specifically ask for status == 'setup' because the start time was not set and that send the ballot to the last index by date.

## Screenshots

![image](https://user-images.githubusercontent.com/4420760/199131583-486f0197-2f72-41c6-a4ca-fcacac5a3fa6.png)
