### PR TITLE
UI for managing DAO token features

### DIFF
--- a/src/css/quasar.variables.sass
+++ b/src/css/quasar.variables.sass
@@ -72,32 +72,32 @@ div.container-xl
   margin-left: auto
   max-width: none
 
-@media (min-width: $breakpoint-sm-min) 
-  div.container,
-  div.container-sm 
-    max-width: $breakpoint-xs - $container-padding
-
-@media (min-width: $breakpoint-md-min) 
-  div.container,
-  div.container-sm,
-  div.container-md 
-    max-width: $breakpoint-sm - $container-padding
-
-@media (min-width: $breakpoint-lg-min) 
+@media (min-width: $breakpoint-lg-min)
   div.container,
   div.container-sm,
   div.container-md,
-  div.container-lg 
+  div.container-lg
     max-width: $breakpoint-md - $container-padding
 
-@media (min-width: $breakpoint-xl-min) 
+@media (min-width: $breakpoint-xl-min)
   div.container,
   div.container-sm,
   div.container-md,
   div.container-lg,
-  div.container-xl 
+  div.container-xl
     max-width: $breakpoint-lg - $container-padding
-    
+
+@media (min-width: $breakpoint-md-min)
+  div.container,
+  div.container-sm,
+  div.container-md
+    max-width: $breakpoint-sm - $container-padding
+
+@media (min-width: $breakpoint-sm-min)
+  div.container,
+  div.container-sm
+    max-width: $breakpoint-xs - $container-padding
+
 // --------------------------------------
 
 $container-padding: 20px

--- a/src/i18n/en-us/index.js
+++ b/src/i18n/en-us/index.js
@@ -190,6 +190,14 @@ export default {
         },
       },
       treasuries: {
+        settings: {
+          burnable: 'If enabled, the token manager can burn their own token',
+          maxmutable: 'If enabled, the token manager can change token max supply',
+          reclaimable: 'If enabled, the token manager can take away tokens from any user without extra permission',
+          stakeable: 'Enable this feature to allow users to stake their tokens',
+          transferable: 'Enable this feature to allow users to transfer their tokens. Consider that this is the primary feature, do not disable this feature unless you know what you are doing',
+          unstakeable: 'If enabled, users who has staked their tokens can not unstake them any more',
+        },
         card: {
           maxSupply: 'Max supply',
           openedBallots: 'Opened decisions',

--- a/src/i18n/en-us/index.js
+++ b/src/i18n/en-us/index.js
@@ -2,6 +2,8 @@ export default {
   common: {
     appName: 'Telos Communities',
     buttons: {
+      reset: 'reset',
+      ok: 'OK',
       cancel: 'Cancel',
       continue: 'Continue',
       create: 'Create',

--- a/src/pages/trails/treasuries/components/TreasuryCard.vue
+++ b/src/pages/trails/treasuries/components/TreasuryCard.vue
@@ -3,6 +3,7 @@ import { mapGetters } from 'vuex';
 import AddVoterDialog from './AddVoterDialog';
 import MintTokenDialog from './MintTokenDialog';
 import TreasuryEditDialog from './TreasuryEditDialog';
+import TreasuryTokenEditDialog from './TreasuryTokenEditDialog';
 
 export default {
   name: 'TreasuryCard',
@@ -10,6 +11,7 @@ export default {
     AddVoterDialog,
     MintTokenDialog,
     TreasuryEditDialog,
+    TreasuryTokenEditDialog,
   },
   props: {
     treasury: { type: Object, required: true },
@@ -19,6 +21,7 @@ export default {
       show: false,
       showMint: false,
       showEdit: false,
+      showToken: false,
     };
   },
   computed: {
@@ -44,6 +47,11 @@ div
     :treasury="treasury"
     @close="showEdit = false"
   )
+  treasury-token-edit-dialog(
+    :show.sync="showToken"
+    :treasury="treasury"
+    @close="showToken = false"
+  )
   q-card
     q-card-section.bg-primary.text-white(:class="`${!treasury.isPreferred ? undefined : 'prefered'}`")
       .text-h6
@@ -62,6 +70,11 @@ div
           v-if="account === treasury.manager"
           name="fas fa-edit"
           @click="showEdit = true"
+        )
+        q-icon.q-ml-sm.cursor-pointer(
+          v-if="account === treasury.manager"
+          name="fas fa-coins"
+          @click="showToken = true"
         )
       .text-right.text-italic {{ treasury.manager }}
     q-card-section.q-mt-lg

--- a/src/pages/trails/treasuries/components/TreasuryTokenEditDialog.vue
+++ b/src/pages/trails/treasuries/components/TreasuryTokenEditDialog.vue
@@ -44,35 +44,27 @@ export default {
 };
 </script>
 
-<template lang="pug">
-q-dialog(
-  v-model="show"
-)
-  q-card.container-sm
-    q-card-section.bg-primary.text-white
-      .text-h6 Edit DAO token features
-    q-card-section
-      p Each DAO has it's own token which is used for vote. From here you can change the token features to alter the token behavior.
-      p Clicking on any feature will display a deascription of it
-    q-card-section.q-pt-none
-      treasury-token-settings-edit(v-model="settings")
-
-    q-card-actions(
-      align="right"
-    )
-      q-btn(
-        flat
-        :label="$t('common.buttons.cancel')"
-        @click="$emit('close')"
-      )
-      q-btn(
-        color="primary"
-        :label="$t('common.buttons.save')"
-        @click="onSaveSettings"
-        :loading="submitting"
-      )
+<template>
+  <q-dialog :model-value="show">
+    <q-card class="container-sm">
+      <q-card-section class="bg-primary text-white">
+        <div class="text-h6">Edit DAO token features</div>
+      </q-card-section>
+      <q-card-section>
+        <p>Each DAO has it's own token which is used for vote. From here you can change the token features to alter the token behavior.</p>
+        <p>Clicking on any feature will display a deascription of it</p>
+      </q-card-section>
+      <q-card-section class="q-pt-none">
+        <treasury-token-settings-edit v-model="settings"></treasury-token-settings-edit>
+      </q-card-section>
+      <q-card-actions :align="'right'">
+        <q-btn flat="flat" :label="$t('common.buttons.cancel')" @click="$emit('close')"></q-btn>
+        <q-btn color="primary" :label="$t('common.buttons.save')" @click="onSaveSettings" :loading="submitting"></q-btn>
+      </q-card-actions>
+    </q-card>
+  </q-dialog>
 </template>
 
-<style lang="sass">
+<style lang="scss">
 
 </style>

--- a/src/pages/trails/treasuries/components/TreasuryTokenEditDialog.vue
+++ b/src/pages/trails/treasuries/components/TreasuryTokenEditDialog.vue
@@ -1,0 +1,76 @@
+<script>
+import { mapActions } from 'vuex';
+import TreasuryTokenSettingsEdit from './TreasuryTokenSettingsEdit';
+
+export default {
+  name: 'TreasuryTokenEditDialog',
+  components: {
+    TreasuryTokenSettingsEdit
+  },
+  props: {
+    show: { type: Boolean, required: true },
+    treasury: { type: Object, required: true },
+  },
+  data() {
+    return {
+      settings: [],
+      submitting: false,
+    };
+  },
+  watch: {
+    show() {
+      if (this.show) {
+        this.settings = this.treasury.settings.map(x => ({key:x.key, value:!!x.value}));
+        console.log('Current settings: ', JSON.stringify(this.settings, null, 4));
+      }
+    }
+  },
+  methods: {
+    ...mapActions('trails', ['editTreasurySettings']),
+    async onSaveSettings() {
+      this.submitting = true;
+      const success = await this.editTreasurySettings({
+        settings: this.settings.map(x => ({key:x.key, value:x.value?1:0})),
+        treasury: this.treasury
+      });
+      this.submitting = false;
+      if (success) {
+        this.showSuccessMsg('Token features updated successfully');
+        this.$emit('close');
+      } else {
+        this.showSuccessMsg('An error has ocurred');
+      }
+    },
+  },
+};
+</script>
+
+<template lang="pug">
+q-dialog(
+  v-model="show"
+)
+  q-card(style="width: 500px; max-width: 80vw;")
+    q-card-section.bg-primary.text-white
+      .text-h6 Edit DAO token features
+    q-card-section
+      | Each DAO has it's own token which is used to vote. From here you can change....
+    q-card-section
+      treasury-token-settings-edit(v-model="settings")
+
+    q-card-actions(
+      align="right"
+    )
+      q-btn(
+        flat
+        :label="$t('common.buttons.cancel')"
+        @click="$emit('close')"
+      )
+      q-btn(
+        color="primary"
+        :label="$t('common.buttons.save')"
+        @click="onSaveSettings"
+        :loading="submitting"
+      )
+</template>
+
+<style lang="sass"></style>

--- a/src/pages/trails/treasuries/components/TreasuryTokenEditDialog.vue
+++ b/src/pages/trails/treasuries/components/TreasuryTokenEditDialog.vue
@@ -21,7 +21,6 @@ export default {
     show() {
       if (this.show) {
         this.settings = this.treasury.settings.map(x => ({key:x.key, value:!!x.value}));
-        console.log('Current settings: ', JSON.stringify(this.settings, null, 4));
       }
     }
   },
@@ -49,12 +48,13 @@ export default {
 q-dialog(
   v-model="show"
 )
-  q-card(style="width: 500px; max-width: 80vw;")
+  q-card.container-sm
     q-card-section.bg-primary.text-white
       .text-h6 Edit DAO token features
     q-card-section
-      | Each DAO has it's own token which is used to vote. From here you can change....
-    q-card-section
+      p Each DAO has it's own token which is used for vote. From here you can change the token features to alter the token behavior.
+      p Clicking on any feature will display a deascription of it
+    q-card-section.q-pt-none
       treasury-token-settings-edit(v-model="settings")
 
     q-card-actions(
@@ -73,4 +73,6 @@ q-dialog(
       )
 </template>
 
-<style lang="sass"></style>
+<style lang="sass">
+
+</style>

--- a/src/pages/trails/treasuries/components/TreasuryTokenSettingsEdit.vue
+++ b/src/pages/trails/treasuries/components/TreasuryTokenSettingsEdit.vue
@@ -1,0 +1,78 @@
+<script>
+import { validation } from '~/mixins/validation';
+
+export default {
+  name: 'TreasuryTokenSettingsEdit',
+  mixins: [validation],
+  props: {
+    modelValue: {
+        type: Array,
+        required: true
+    },
+  },
+  data() {
+    return {
+      preValue: {},
+      selected: {
+        key: '',
+        body: ''
+      }
+    };
+  },
+  async mounted() {
+    this.remember();
+  },
+  methods: {
+    remember(newValue) {
+      this.preValue = (newValue || this.modelValue).map(x => ({...x}))
+    }
+  },
+  watch: {
+    modelValue: {
+      handler:function(newval) {
+        let changes = this.preValue.filter((x,i) => {          
+          let result = newval[i].value != x.value;
+          return result;
+        });
+
+        console.log('changes: ', changes);
+        if (changes.length == 1) {
+          this.selected = {
+            key: changes[0].key,
+            body: 'pages.trails.treasuries.settings.' + changes[0].key
+          }
+        }
+        this.remember();
+      },
+      deep:true
+    }
+  }
+};
+</script>
+
+<template lang="pug">
+.row.tt-editor
+  .col-sm-5.q-mb-md.tt-editor__checkboxes
+    q-list.tt-editor__checkbox-list
+      q-item.tt-editor__checkbox-item(
+        v-for="(coso,index) in modelValue"
+        dense
+      )
+        q-checkbox.tt-editor__checkbox(
+          v-model="modelValue[index].value"
+          :label="modelValue[index].key"
+        )
+  .col-sm-7.tt-editor__doc
+    .q-mt-sm.text-h6.tt-editor__doc-title {{ selected.key }}
+    .q-mt-md.tt-editor__doc-body {{ $t(selected.body) }}
+    
+</template>
+
+<style lang="sass">
+
+.tt-editor__doc
+  padding-left: 24px
+.tt-editor__doc-title
+  font-weight: bold
+
+</style>

--- a/src/pages/trails/treasuries/components/TreasuryTokenSettingsEdit.vue
+++ b/src/pages/trails/treasuries/components/TreasuryTokenSettingsEdit.vue
@@ -12,6 +12,7 @@ export default {
   },
   data() {
     return {
+      list: [],
       preValue: {},
       selected: {
         key: '',
@@ -20,15 +21,16 @@ export default {
     };
   },
   async mounted() {
+    this.list = this.modelValue.map(x => x); // clean copy
     this.remember();
   },
   methods: {
     remember(newValue) {
-      this.preValue = (newValue || this.modelValue).map(x => ({...x}))
+      this.preValue = (newValue || this.list).map(x => ({...x}))
     }
   },
   watch: {
-    modelValue: {
+    list: {
       handler:function(newval) {
         let changes = this.preValue.filter((x,i) => {          
           let result = newval[i].value != x.value;
@@ -49,29 +51,35 @@ export default {
 };
 </script>
 
-<template lang="pug">
-.row.tt-editor
-  .col-sm-5.q-mb-md.tt-editor__checkboxes
-    q-list.tt-editor__checkbox-list
-      q-item.tt-editor__checkbox-item(
-        v-for="(coso,index) in modelValue"
-        dense
-      )
-        q-checkbox.tt-editor__checkbox(
-          v-model="modelValue[index].value"
-          :label="modelValue[index].key"
-        )
-  .col-sm-7.tt-editor__doc
-    .q-mt-sm.text-h6.tt-editor__doc-title {{ selected.key }}
-    .q-mt-md.tt-editor__doc-body {{ $t(selected.body) }}
-    
+<template>
+  <div class="row tt-editor">
+    <div class="col-sm-5 q-mb-md tt-editor__checkboxes">
+      <q-list class="tt-editor__checkbox-list">
+        <q-item class="tt-editor__checkbox-item" v-for="(coso,index) in list" dense="dense" :key="index">
+          <q-checkbox class="tt-editor__checkbox"
+            v-model="list[index].value"
+            :label="list[index].key"
+            @update:model-value="$emit('update:modelValue', list)"
+          ></q-checkbox>
+        </q-item>
+      </q-list>
+    </div>
+    <div class="col-sm-7 tt-editor__doc">
+      <div class="q-mt-sm text-h6 tt-editor__doc-title">{{ selected.key }}</div>
+      <div class="q-mt-md tt-editor__doc-body">{{ $t(selected.body) }}</div>
+    </div>
+  </div>
 </template>
 
-<style lang="sass">
 
-.tt-editor__doc
-  padding-left: 24px
-.tt-editor__doc-title
+<style lang="scss">
+
+.tt-editor__doc {
+  padding-left: 24px;
+}
+
+.tt-editor__doc-title {
   font-weight: bold
+}
 
 </style>

--- a/src/pages/trails/treasuries/components/TreasuryTokenSettingsEdit.vue
+++ b/src/pages/trails/treasuries/components/TreasuryTokenSettingsEdit.vue
@@ -35,7 +35,6 @@ export default {
           return result;
         });
 
-        console.log('changes: ', changes);
         if (changes.length == 1) {
           this.selected = {
             key: changes[0].key,

--- a/src/store/trails/actions.js
+++ b/src/store/trails/actions.js
@@ -500,7 +500,7 @@ export const fetchTreasury = async function ({ commit }, treasury) {
 
 export const addTreasury = async function (
   { commit, state, rootState },
-  { manager, maxSupply, access, title, description }
+  { manager, maxSupply, access, title, description, settings }
 ) {
   const deposit = state.fees.find((fee) => fee.key === 'treasury').value;
   const notification = {
@@ -509,7 +509,7 @@ export const addTreasury = async function (
     content: `Treasury manager: ${manager}, supply: ${maxSupply}, deposit: ${deposit}`,
   };
   try {
-    const actions = [
+    let actions = [
       {
         account: 'eosio.token',
         name: 'transfer',
@@ -540,6 +540,18 @@ export const addTreasury = async function (
         },
       },
     ];
+
+    let toggles = settings.filter(x => x.value).map(x => ({
+      account: 'telos.decide',
+      name: 'toggle',
+      data: {
+        treasury_symbol: supplyToAsset(maxSupply),
+        setting_name: x.key
+      },
+    }));
+
+    actions = actions.concat(toggles);
+
     const transaction = await this.$api.signTransaction(actions);
     notification.status = 'success';
     notification.transaction = transaction;

--- a/src/store/trails/actions.js
+++ b/src/store/trails/actions.js
@@ -585,6 +585,40 @@ export const editTreasury = async function (
   return notification.status === 'success';
 };
 
+export const editTreasurySettings = async function (
+  { commit, dispatch},
+  { settings, treasury }
+) {
+  const notification = {
+    icon: 'fas fa-edit',
+    title: 'notifications.trails.editTreasury',
+    content: `Treasury: ${treasury.title}`,
+  };
+  try {
+    let actions = settings.filter((x,i) => treasury.settings[i].value != x.value)
+    .map(x => ({
+      account: 'telos.decide',
+      name: 'toggle',
+      data: {
+        treasury_symbol: supplyToAsset(treasury.symbol),
+        setting_name: x.key
+      },
+    }));
+
+    const transaction = await this.$api.signTransaction(actions);
+    commit('updateTreasurySettings', { settings, treasury });
+    await dispatch('fetchTreasury', supplyToSymbol(treasury.max_supply));
+
+    notification.status = 'success';
+    notification.transaction = transaction;
+  } catch (e) {
+    notification.status = 'error';
+    notification.error = e;
+  }
+  commit('notifications/addNotification', notification, { root: true });
+  return notification.status === 'success';
+};
+
 export const mint = async function (
   { commit },
   { to, quantity, memo, supply }

--- a/src/store/trails/mutations.js
+++ b/src/store/trails/mutations.js
@@ -209,6 +209,13 @@ export const addTreasuries = (state, { rows, more }) => {
   state.treasuries.list.loaded = !more;
 };
 
+export const updateTreasurySettings = (state, { settings, treasury }) => {
+  let obj = state.treasuries.list.data.find(
+    (t) => t.max_supply === treasury.max_supply
+  );
+  obj.settings = settings;
+};
+
 export const updateTreasury = (state, { title, description, treasury }) => {
   const obj = state.treasuries.list.data.find(
     (t) => t.max_supply === treasury.max_supply


### PR DESCRIPTION
# Fixes #207

## Description
Since the DAO token is the main source of voting power it is essential to be able to at least transfer the tokens between voters in order to vote. But this functionality, among others, is disabled by default. So this PR includes the best initial configuration default for new DAOS and also provides two new ways of changing that configuration:
- 1. in the creation process there's a new field showing the tokens configuration and a button to open a dialog for the edition
- 2. Once the DAO is created, the manager can edit the token configuration by clicking on the new button on the DAO card header to open the same edition dialog.

## Screenshots

![image](https://user-images.githubusercontent.com/4420760/200151171-7522e2db-d012-4b00-9c50-495ac13d8318.png)
![image](https://user-images.githubusercontent.com/4420760/200151177-522872f5-3f71-4131-af59-c56e1bc9e425.png)
![image](https://user-images.githubusercontent.com/4420760/200151189-b1cb62eb-717b-4ca6-9488-4b86eb2e3089.png)

