### PR TITLE
unlocking the creation of unopened ballots in BallotForm

### DIFF
--- a/src/pages/trails/ballots/components/BallotForm.vue
+++ b/src/pages/trails/ballots/components/BallotForm.vue
@@ -819,7 +819,7 @@ q-dialog(
             p(:class="textClass")
               | You can open this ballot for voting right away or you
               | can create the ballot and skip this step for later.
-            q-checkbox(v-model="openForVoting" disable) Open for voting right away
+            q-checkbox(v-model="openForVoting") Open for voting right away
             q-input(
               ref="endTime"
               v-model="form.endTime"
@@ -852,7 +852,6 @@ q-dialog(
                       v-model="form.endTime"
                       mask="YYYY-MM-DD HH:mm"
                     )
-            small Note: Proposals will be eligible for voting once they are created.
         q-step(
           :name="5"
           title="Create Ballot"


### PR DESCRIPTION
# Fixes #226

## Description
All the components are prepared to handle not opened ballots but the current wizard implementation still has disabled the option to not open the ballot immediately. This PR fixes that.

## Screenshots

![image](https://user-images.githubusercontent.com/4420760/201199556-db3a26e0-63dc-43d4-817a-956c80d9d25f.png)
