### PR TITLE
bugfix on handling the filter list when is empty

### DIFF
--- a/src/pages/trails/ballots/list/BallotsList.vue
+++ b/src/pages/trails/ballots/list/BallotsList.vue
@@ -169,8 +169,7 @@ export default {
         filterBallots(ballots) {
 
             const ballotFilteredByStatuses = ballots.filter((b) => {
-
-                if (this.statuses) {
+                if (Object.keys(this.statuses).length > 0) {
 
                     if (this.statuses.includes('active')) {
                         if (this.isBallotOpened(b)) {
@@ -191,8 +190,10 @@ export default {
                     }
 
                     return this.statuses.includes(b.status);
+                } else {
+                    // If the list is empty, we show all ballots
+                    return true;
                 }
-
             });
 
             const ballotFilteredByCategory = ballotFilteredByStatuses.filter((b) => {


### PR DESCRIPTION
# Fixes #239

## Description
The cross icon in the filter buttons means "apply no filters" so all the ballots should be should. This specific situation was not handled by the new implementation (cleaner but with this little bug inside).

The case was properly taken care of and now it works.

## screenshots

![image](https://user-images.githubusercontent.com/4420760/202052222-a7d7a7ad-46f5-4d2c-b0e3-043061fa650c.png)

