### PR TITLE
refreshing the ballot list if routes changes

### DIFF
--- a/src/pages/trails/ballots/list/BallotsList.vue
+++ b/src/pages/trails/ballots/list/BallotsList.vue
@@ -274,6 +274,7 @@ export default {
     watch: {
         $route(to) {
             this.showBallot = !!to.params.id;
+            this.updateBallots();
         },
         account() {
             this.fetchUserVotes();


### PR DESCRIPTION
# Fixes #238 

## Description
Navigating from the Elections and the Proposals pages back and forth did not update the ballot shown. This PR fixes that.
