### PR TITLE
changing the button "take me to my profile" to "sign in"

### DIFF
--- a/src/i18n/en-us/index.js
+++ b/src/i18n/en-us/index.js
@@ -113,6 +113,7 @@ export default {
                 buttons: {
                     continue: 'Continue',
                     goToProfile: 'Take me to my profile',
+                    signIn: 'Sign in',
                     verify: 'Verify Phone Number',
                     genKeys: 'Generate Keys',
                 },

--- a/src/pages/accounts/add/CongratulationsPage.vue
+++ b/src/pages/accounts/add/CongratulationsPage.vue
@@ -20,10 +20,10 @@ q-page.flex.align-center.column.q-pa-lg.congratulations
   .col-3
     q-btn.full-width(
       color="primary"
-      :label="$t('pages.accounts.add.buttons.goToProfile')"
+      :label="$t('pages.accounts.add.buttons.signIn')"
       size="lg"
       unelevated
-      to="/"
+      to="/login/?returnUrl=/"
     )
 </template>
 


### PR DESCRIPTION
# Fixes #204

## Description
The button "Take to my account" was just redirecting to home and the text did not match the action. Now the button says "sign in" and actually redirects the user to the signing page.

![image](https://user-images.githubusercontent.com/4420760/202587480-46c675ea-2084-4917-8481-f144b4099615.png)
