### PR TITLE
fix: enable arbitration portal for mainnet

### DIFF
--- a/src/components/layout/HeaderMenu.vue
+++ b/src/components/layout/HeaderMenu.vue
@@ -2,15 +2,10 @@
 import { mapGetters } from 'vuex';
 import ResolveMenu from './ResolveMenu.vue';
 
-const NETWORK_ENV = process.env.NETWORK_ENV;
-
 export default {
     name: 'HeaderMenu',
     computed: {
         ...mapGetters('accounts', ['isAuthenticated']),
-        isTestnet () {
-            return NETWORK_ENV === 'testnet';
-        }
     },
     props: {
         activeFilter: {},
@@ -87,9 +82,7 @@ q-tabs(
           :class="[el.filter === localFileter ? 'active-tab': '']"
         )
     div.custom-separator
-  ResolveMenu(
-    v-if="isTestnet"
-  )
+  ResolveMenu
 </template>
 
 <style lang="sass">


### PR DESCRIPTION
# Fixes #271 

## Test scenarios
- 'Resolve' option available on [mainnet deploy preview link](https://deploy-preview-270--telos-app-native-mainnet.netlify.app/), functionality options consistent with testnet

## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have cleaned up the code in the areas my change touches
-   [x] My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [x] I have removed any unnecessary console messages
-   [x] I have included all english text to the translation file
-   [x] I have created a new issue with the required translations for the currently supported languages
