### PR TITLE
Display Resolve menu in sidebar on mobile (mainnet)

### DIFF
--- a/src/components/layout/LeftMenu.vue
+++ b/src/components/layout/LeftMenu.vue
@@ -1,8 +1,6 @@
 <script>
 import ResolveSidebarItem from './ResolveSidebarItem.vue';
 
-const NETWORK_ENV = process.env.NETWORK_ENV;
-
 export default {
     name: 'LeftMenu',
     components: {
@@ -42,11 +40,6 @@ export default {
             this.clientWidth = window.innerWidth;
         },
     },
-    computed : {
-        isTestnet () {
-            return NETWORK_ENV === 'testnet';
-        }
-    }
 };
 </script>
 
@@ -80,9 +73,7 @@ q-scroll-area.left-menu(style="height: 100%; border-right: 1px solid #ddd")
       :to="item.route"
       ripple
     )
-    ResolveSidebarItem(
-      v-if="isTestnet"
-    )
+    ResolveSidebarItem()
 </template>
 
 <style lang="sass">


### PR DESCRIPTION
# Fixes #291

## Description

Sidebar menu conditionally displays Resolve sub-menu based on `NETWORK` variable being set to `testnet`, which is why it does not display on mainnet.

## Test scenarios

<!---
Describe the test scenarios that you ran to verify your changes.
Include any relevant configuration to required to reproduce them.
-->

## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have cleaned up the code in the areas my change touches
-   [x] My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [x] I have removed any unnecessary console messages
-   [x] I have included all english text to the translation file and/or created a new issue with the required translations for the currently supported languages
-   [x] I have tested for mobile functionality and responsiveness
-   [x] I have added appropriate test coverage 
