### PR TITLE
Make testnet faucet page more efficient by adding input validation #259

### DIFF
--- a/src/pages/testnet/DevelopersPage.vue
+++ b/src/pages/testnet/DevelopersPage.vue
@@ -16,6 +16,24 @@ export default {
             submitting: false,
         };
     },
+    computed: {
+    isCreateAccountButtonDisabled() {
+      return (
+        !this.form.account_name ||
+        !this.form.owner_key ||
+        !this.form.active_key ||
+        this.submitting
+      );
+    },
+    isAnyInputInvalid() {
+      return (
+        !this.form.account_name ||
+        !/^EOS[0-9A-Za-z]{50}$/.test(this.form.owner_key) ||
+        !/^EOS[0-9A-Za-z]{50}$/.test(this.form.active_key) 
+       
+      );
+    },
+  },
     methods: {
         ...mapActions('testnet', ['faucet', 'evmFaucet', 'account']),
         async onFaucet() {
@@ -85,6 +103,7 @@ q-page.flex.flex-center
         ref="owner_key"
         v-model="form.owner_key"
         color="accent"
+        :rules="[ val => /^EOS[0-9A-Za-z]{50}$/.test(val) || 'Please provide a valid Owner key']"
         label="Owner key"
         outlined
       )
@@ -92,6 +111,8 @@ q-page.flex.flex-center
         ref="active_key"
         v-model="form.active_key"
         color="accent"
+        :rules="[ val => /^EOS[0-9A-Za-z]{50}$/.test(val) || 'Please provide a valid Active key']"
+
         label="Active key"
         outlined
       )
@@ -101,6 +122,7 @@ q-page.flex.flex-center
         size="lg"
         unelevated
         :loading="submitting"
+        :disable="isAnyInputInvalid"
         @click="onAccount"
       )
 


### PR DESCRIPTION
Make testnet faucet page more efficient by adding input validation #259 

## Description


I have disabled the button until valid input is given and included a computed property isCreateAccountButtonDisabled that checks for valid input conditions. If any of the input fields are empty or if the Telos owner key doesn't match the specified pattern, the button will remain disabled. This helps ensure that the button is only enabled when valid input is provided, addressing the issue


## Test scenarios

The test scenarios included verifying the button's disabled state under different conditions. Initially, the button remained enabled despite invalid or empty input. After the code changes, the button correctly disables when any input field is blank or when invalid input is provided for the Telos owner key and active key. The validation ensures that the "Create testnet account" button is only clickable when valid input is provided.

## Checklist:

-   [ ] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have cleaned up the code in the areas my change touches
-   [ ] My changes generate no new warnings
-   [ ] Any dependent changes have been merged and published in downstream modules
-   [ ] I have checked my code and corrected any misspellings
-   [ ] I have removed any unnecessary console messages
-   [ ] I have included all english text to the translation file and/or created a new issue with the required translations for the currently supported languages
-   [ ] I have tested for mobile functionality and responsiveness
-   [ ] I have added appropriate test coverage 

## Screenshot
![image](https://github.com/telosnetwork/app-telos-native/assets/104358692/381be912-e17d-45ef-9f6a-e2a7888a018d)
