### PR TITLE
Use correct permission when signing transactions

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,5 +11,5 @@
     "javascriptreact",
     "typescript",
     "vue"
-  ]
+  ],
 }

--- a/src/boot/api.js
+++ b/src/boot/api.js
@@ -5,80 +5,78 @@ import { Notify } from 'quasar';
 
 
 const signTransaction = async function (actions) {
-
-    console.log(this.state.accounts.user);
-    actions.forEach((action) => {
-        if (!action.authorization || !action.authorization.length) {
-            action.authorization = [
-                {
-                    actor: this.state.accounts.account,
-                    permission: this.state.accounts.user.requestPermission || this.state.accounts.user.permission ,
-                },
-            ];
-        }
-    });
-    let transaction = null;
-    try {
-        transaction = await this.$ualUser.signTransaction(
-            {
-                actions,
-            },
-            {
-                blocksBehind: 3,
-                expireSeconds: 30,
-            }
-        );
-        Notify.create({ type: 'positive', message: 'Transaction signed' });
-    } catch (e) {
-        if (e.cause.error) {
-            const msg = e.cause.error.details[0].message.replace(
-                /assertion failure with message: /g,
-                ''
-            );
-            Notify.create({ type: 'negative', message: msg });
-            throw msg;
-        } else {
-            Notify.create({ type: 'negative', message: e.message });
-            throw e;
-        }
+  actions.forEach((action) => {
+    if (!action.authorization || !action.authorization.length) {
+      action.authorization = [
+        {
+          actor: this.state.accounts.account,
+          permission: this.state.accounts.user.requestPermission || this.state.accounts.user.permission,
+        },
+      ];
     }
-    return transaction;
+  });
+  let transaction = null;
+  try {
+    transaction = await this.$ualUser.signTransaction(
+      {
+        actions,
+      },
+      {
+        blocksBehind: 3,
+        expireSeconds: 30,
+      }
+    );
+    Notify.create({ type: 'positive', message: 'Transaction signed' });
+  } catch (e) {
+    if (e.cause.error) {
+      const msg = e.cause.error.details[0].message.replace(
+        /assertion failure with message: /g,
+        ''
+      );
+      Notify.create({ type: 'negative', message: msg });
+      throw msg;
+    } else {
+      Notify.create({ type: 'negative', message: e.message });
+      throw e;
+    }
+  }
+  return transaction;
 };
 
 const getTableRows = async function (options) {
-    try {
-        return this.$defaultApi.rpc.get_table_rows({
-            json: true,
-            ...options,
-        });
-    } catch (e) {
-        console.error(e);
-    }
+  try {
+    return this.$defaultApi.rpc.get_table_rows({
+      json: true,
+      ...options,
+    });
+  } catch (e) {
+    console.error(e);
+  }
 };
 
 const getAccount = async function (account) {
-    try {
-        return this.$defaultApi.rpc.get_account(account);
-    } catch (e) {
-        console.error(e);
-    }
+  try {
+    return this.$defaultApi.rpc.get_account(account);
+  } catch (e) {
+    console.error(e);
+  }
 };
 
 // "async" is optional;
 // more info on params: https://v2.quasar.dev/quasar-cli/boot-files
 export default boot(async ({ store }) => {
-    const rpc = new JsonRpc(
-        `${process.env.NETWORK_PROTOCOL}://${process.env.NETWORK_HOST}:${process.env.NETWORK_PORT}`
-    );
-    store['$defaultApi'] = new Api({
-        rpc,
-        textDecoder: new TextDecoder(),
-        textEncoder: new TextEncoder(),
-    });
+  const rpc = new JsonRpc(
+    `${process.env.NETWORK_PROTOCOL}://${process.env.NETWORK_HOST}:${process.env.NETWORK_PORT}`
+  );
+  store['$defaultApi'] = new Api({
+    rpc,
+    textDecoder: new TextDecoder(),
+    textEncoder: new TextEncoder(),
+  });
 
-    store['$api'] = {
-        signTransaction: signTransaction.bind(store),
-        getTableRows: getTableRows.bind(store),
-        getAccount: getAccount.bind(store),
-    };
+  store['$api'] = {
+    signTransaction: signTransaction.bind(store),
+    getTableRows: getTableRows.bind(store),
+    getAccount: getAccount.bind(store),
+  };
 });


### PR DESCRIPTION
Fixes an issue where "active" permission was always used even if the account was logged in using another permission. The fix works for Anchor/cleos login.