### PR TITLE
#350 | Update from tTLOS to ETH on zkEVM Faucet

### DIFF
--- a/src/i18n/en-us/index.js
+++ b/src/i18n/en-us/index.js
@@ -325,8 +325,8 @@ export default {
             send_tlos_telos_subtitle: 'Use this tab to send TLOS tokens to a Telos native account.',
             send_tlos_evm_title: 'Send TLOS to EVM Address',
             send_tlos_evm_subtitle: 'Send TLOS tokens to an EVM compatible address with this option.',
-            send_tlos_zkevm_title: 'Send tTLOS to zkEVM Address',
-            send_tlos_zkevm_subtitle: 'Send tTLOS tokens to a zkEVM compatible address with this option.',
+            send_tlos_zkevm_title: 'Send ETH to zkEVM Address',
+            send_tlos_zkevm_subtitle: 'Send ETH tokens to a zkEVM compatible address with this option.',
         },
         testnetEvmFaucet: {
             title: 'Get testnet EVM TLOS',

--- a/src/pages/testnet/DevelopersPage.vue
+++ b/src/pages/testnet/DevelopersPage.vue
@@ -54,7 +54,7 @@ const tlosEvmLabel = computed(() => {
 });
 
 const tlosZkEvmLabel = computed(() => {
-    return $q.screen.gt.sm ? 'Send tTLOS (ZK-EVM)' : 'ZK-EVM tTLOS';
+    return $q.screen.gt.sm ? 'Send ETH (ZK-EVM)' : 'ZK-EVM ETH';
 });
 
 // Result Notifications


### PR DESCRIPTION
# Fixes #350
The UI for the Faucet was updated. Instead of `tTLOS` we have `ETH` now.

## Test Scenarios
https://350-create-new-tab-in-dev-to.app-telos-native.pages.dev/testnet/developers?tab=tlos-zkevm

![image](https://github.com/user-attachments/assets/d8d48021-799d-4f19-8890-1cb553485028)
