### PR TITLE
Fix validators: live chain API + proper benchmark pagination + correct network labels

### DIFF
--- a/env.js
+++ b/env.js
@@ -41,6 +41,7 @@ const MAINNET = {
   BLOCKCHAIN_EXPLORER: "https://explorer.telos.net",
   NETWORK_ENV: "mainnet",
   VALIDATORS_API: "https://telos-wallet-og.netlify.app/.netlify/functions/validators",
+  BENCHMARK_API: "https://telos-wallet-og.netlify.app/.netlify/functions/cpu-benchmark",
   ARB_CONTRACT: 'arbitration',
 };
 

--- a/env.js
+++ b/env.js
@@ -26,6 +26,7 @@ const TESTNET = {
   HYPERION_URL: "https://testnet.telos.net",
   BLOCKCHAIN_EXPLORER: "https://explorer-test.telos.net",
   NETWORK_ENV: "testnet",
+  VALIDATORS_API: "https://telos-wallet-og.netlify.app/.netlify/functions/validators?network=testnet",
   ARB_CONTRACT: 'testtelosarb',
 };
 
@@ -39,6 +40,7 @@ const MAINNET = {
   HYPERION_URL: "https://mainnet.telos.net",
   BLOCKCHAIN_EXPLORER: "https://explorer.telos.net",
   NETWORK_ENV: "mainnet",
+  VALIDATORS_API: "https://telos-wallet-og.netlify.app/.netlify/functions/validators",
   ARB_CONTRACT: 'arbitration',
 };
 

--- a/src/pages/trails/ballots/view/BallotView.vue
+++ b/src/pages/trails/ballots/view/BallotView.vue
@@ -52,15 +52,11 @@ export default {
                 return;
             }
             await this.fetchVotesForBallot({
-              name: this.ballot.ballot_name,
-              limit: this.ballot.total_voters,
+                name: this.ballot.ballot_name,
+                limit: this.ballot.total_voters,
             });
             window.addEventListener('scroll', this.updateScroll);
             this.loading = false;
-            console.log('Ballot:', this.ballot); // FIXME: remove
-            console.log('iframeUrl:', this.iframeUrl); // FIXME: remove
-            console.log('optionData:', this.optionData); // FIXME: remove
-            console.log('shapedDescription:', this.shapedDescription); // FIXME: remove
         } catch (e) {
             console.error(e);
         }

--- a/src/pages/trails/ballots/view/BallotView.vue
+++ b/src/pages/trails/ballots/view/BallotView.vue
@@ -52,11 +52,15 @@ export default {
                 return;
             }
             await this.fetchVotesForBallot({
-                name: this.ballot.ballot_name,
-                limit: this.ballot.total_voters,
+              name: this.ballot.ballot_name,
+              limit: this.ballot.total_voters,
             });
             window.addEventListener('scroll', this.updateScroll);
             this.loading = false;
+            console.log('Ballot:', this.ballot); // FIXME: remove
+            console.log('iframeUrl:', this.iframeUrl); // FIXME: remove
+            console.log('optionData:', this.optionData); // FIXME: remove
+            console.log('shapedDescription:', this.shapedDescription); // FIXME: remove
         } catch (e) {
             console.error(e);
         }
@@ -103,11 +107,32 @@ export default {
             }
         },
         shapedDescription() {
+            // first, try to parse the description as an url
             const urlRegex = /((http|https):\/\/[^\s]+)/g;
             const shaped = this.ballot.readableDescription.replace(
                 urlRegex,
                 '<a href="$1" rel="noopener noreferrer" target="_blank">$1</a>'
             );
+            if (shaped === this.ballot.readableDescription) {
+                // if no urls were found, try something else
+                // "<label with spaces>: <link> <label>: <link> ... <CID>"
+                // ej: "Medium Article: https://bit.ly/3UBwzFE Amended Section #10: https://bit.ly/3JPtTQ2 Amended Section #44: https://bit.ly/3wqd76Y Amended Section #49: https://bit.ly/3WrULgu"
+                // final string should be:
+                // "<ul><li>Medium Article: <a href='https://bit.ly/3UBwzFE'>https://bit.ly/3UBwzFE</a></li><li>Amended Section #10: <a href='https://bit.ly/3JPtTQ2'>https://bit.ly/3JPtTQ2</a></li><li>Amended Section #44: <a href='https://bit.ly/3wqd76Y'>https://bit.ly/3wqd76Y</a></li><li>Amended Section #49: <a href='https://bit.ly/3WrULgu'>https://bit.ly/3WrULgu</a></li></ul>";
+                const completeFormatRegex = /(.+: (http|https):\/\/[^\s]+ )+/;
+                if (completeFormatRegex.test(this.ballot.description)) {
+                    const linksRegex = /(.+?: .+? )/g;
+                    const links = this.ballot.description.match(linksRegex);
+                    let result = '<ul>';
+                    links.forEach((link) => {
+                        const [label, _url] = link.split(': ');
+                        const url = _url.trim();
+                        result += `<li>${label}: <a target='_blank' href='${url}'>${url}</a></li>`;
+                    });
+                    result += '</ul>';
+                    return result;
+                }
+            }
             return shaped;
         },
         iframeUrl() {

--- a/src/pages/validators/ValidatorData.vue
+++ b/src/pages/validators/ValidatorData.vue
@@ -24,7 +24,8 @@ import ValidatorDataChart from './components/ValidatorDataChart.vue';
 import ValidatorDataTable from './components/ValidatorDataTable.vue';
 
 // Live API — replaces stale S3 bucket telos-producer-validation
-const VALIDATORS_API = 'https://telos-wallet-og.netlify.app/.netlify/functions/validators';
+// Set via VALIDATORS_API env var (mainnet + testnet builds)
+const VALIDATORS_API = process.env.VALIDATORS_API;
 
 export default {
     // eslint-disable-next-line vue/multi-word-component-names

--- a/src/pages/validators/ValidatorData.vue
+++ b/src/pages/validators/ValidatorData.vue
@@ -23,7 +23,8 @@ import { mapGetters } from 'vuex';
 import ValidatorDataChart from './components/ValidatorDataChart.vue';
 import ValidatorDataTable from './components/ValidatorDataTable.vue';
 
-const BUCKET_URL = 'https://telos-producer-validation.s3.amazonaws.com';
+// Live API — replaces stale S3 bucket telos-producer-validation
+const VALIDATORS_API = 'https://telos-wallet-og.netlify.app/.netlify/functions/validators';
 
 export default {
     // eslint-disable-next-line vue/multi-word-component-names
@@ -57,22 +58,13 @@ export default {
     methods: {
         async getData() {
             try {
-                const objectList = await axios.get(BUCKET_URL);
-                const lastKey = this.getLastKey(objectList);
-                this.producerData = (await axios.get(`${BUCKET_URL}/${lastKey}`)).data;
+                const response = await axios.get(VALIDATORS_API);
+                this.producerData = response.data;
+                this.lastUpdated = new Date().toISOString();
                 await this.getVotes();
             } catch (err) {
                 console.log('Error', err);
             }
-        },
-        getLastKey(objectList) {
-            const parser = new DOMParser();
-            const contentsArray = parser
-                .parseFromString(objectList.data, 'text/xml')
-                .getElementsByTagName('Contents');
-            const lastEntry = contentsArray[contentsArray.length - 1];
-            this.lastUpdated = lastEntry.childNodes[1].textContent;
-            return lastEntry.childNodes[0].textContent;
         },
         async getVotes() {
             if (this.account) {

--- a/src/pages/validators/components/ValidatorDataChart.vue
+++ b/src/pages/validators/components/ValidatorDataChart.vue
@@ -23,7 +23,7 @@ export default {
         return {
             chartOptions: {
                 title: {
-                    text: 'Mainnet Validator CPU Performance',
+                    text: `${process.env.NETWORK_ENV === 'testnet' ? 'Testnet' : 'Mainnet'} Validator CPU Performance`,
                 },
                 credits: {
                     enabled: false,

--- a/src/pages/validators/components/ValidatorDataTable.vue
+++ b/src/pages/validators/components/ValidatorDataTable.vue
@@ -285,7 +285,8 @@ export default {
                 .utc(this.lastUpdated)
                 .local()
                 .format('YYYY-MM-DD HH:mm');
-            return `Mainnet Validators (${localTime})`;
+            const networkLabel = process.env.NETWORK_ENV === 'testnet' ? 'Testnet' : 'Mainnet';
+            return `${networkLabel} Validators (${localTime})`;
         },
         maxSelected() {
             return this.currentVote.length === MAX_VOTE_PRODUCERS;

--- a/src/store/validators/actions.js
+++ b/src/store/validators/actions.js
@@ -1,66 +1,114 @@
-const moment = require('moment');
+const moment = require("moment");
+
+const BENCHMARK_FILTER = "eosmechanics:cpu";
+const HYPERION_ACTIONS_PATH = "v2/history/get_actions";
+
+function getActionTimestamp(action) {
+  return action.timestamp || action["@timestamp"];
+}
+
+function getActionPoint(action) {
+  const producer = action.producer;
+  const cpuUs = Number(action.cpu_usage_us);
+  const timestamp = getActionTimestamp(action);
+
+  if (!producer || Number.isNaN(cpuUs) || !timestamp) {
+    return null;
+  }
+
+  return {
+    producer,
+    point: [moment(timestamp).valueOf(), cpuUs],
+  };
+}
 
 export async function loadBenchmarks({ commit }, { days }) {
-    // TODO: Paginate...
-    //   get the global sequence of the last action, use it in globalsequence filter on the next request
-    //   for the globalsequence filter, do $LAST_ACTION_SEQUENCE-Integer.max
-    //   until we get back less than the limit, which indicates the end
+  try {
+    const latestBenchmarks = await this.$hyperion.get(HYPERION_ACTIONS_PATH, {
+      params: {
+        filter: BENCHMARK_FILTER,
+        limit: 1,
+        sort: "desc",
+      },
+    });
+
+    const latestAction = latestBenchmarks.data.actions[0];
+
+    if (!latestAction) {
+      commit("validators/setBenchmarks", [], { root: true });
+      return {
+        benchmarks: [],
+        latestTimestamp: null,
+      };
+    }
+
+    // The live benchmark stream can pause for long stretches. Anchor the
+    // display window to the latest available benchmark so the graph keeps
+    // rendering useful data instead of an empty recent range.
     let haveMore = true;
-    let batch = 0;
     let params = {
-        filter: 'eosmechanics:cpu',
-        after: moment
-            .utc()
-            .subtract(days, 'days')
-            .format('YYYY-MM-DDTHH:mm:ss.SSS[Z]'),
-        limit: 1000,
-        sort: 'asc',
+      filter: BENCHMARK_FILTER,
+      after: moment
+        .utc(getActionTimestamp(latestAction))
+        .subtract(days, "days")
+        .format("YYYY-MM-DDTHH:mm:ss.SSS[Z]"),
+      limit: 1000,
+      sort: "asc",
     };
     let bpMap = {};
+
     while (haveMore) {
-        console.log(`Doing query with ${JSON.stringify(params)}`);
-        const benchmarks = await this.$hyperion.get('v2/history/get_actions', {
-            params,
-        });
-        let acts = benchmarks.data.actions;
-        let batchCount = acts.length;
-        haveMore = params.limit === batchCount;
-        console.log(
-            `Batch ${++batch} had ${batchCount} actions and is at global_sequence ${
-                params.global_sequence
-            }`
-        );
-        let biggest = 0;
-        for (let i = 0; i < acts.length; i++) {
-            if (acts[i].global_sequence > biggest) {
-                biggest = acts[i].global_sequence;
-            }
-            const action = acts[i];
-            const producer = action.producer;
-            const cpuUs = action.cpu_usage_us;
-            const timestamp = action.timestamp;
-            const momentTimestamp = moment(timestamp);
-            const point = [momentTimestamp.valueOf(), cpuUs];
-            if (!bpMap.hasOwnProperty(producer)) {
-                bpMap[producer] = [point];
-            } else {
-                bpMap[producer].push(point);
-            }
+      const benchmarks = await this.$hyperion.get(HYPERION_ACTIONS_PATH, {
+        params,
+      });
+      let acts = benchmarks.data.actions || [];
+      let biggest = 0;
+
+      acts.forEach((action) => {
+        if (action.global_sequence > biggest) {
+          biggest = action.global_sequence;
         }
+
+        const benchmarkPoint = getActionPoint(action);
+
+        if (!benchmarkPoint) {
+          return;
+        }
+
+        const { producer, point } = benchmarkPoint;
+
+        if (!Object.prototype.hasOwnProperty.call(bpMap, producer)) {
+          bpMap[producer] = [point];
+        } else {
+          bpMap[producer].push(point);
+        }
+      });
+
+      haveMore = acts.length === params.limit && biggest > 0;
+
+      if (haveMore) {
         params.global_sequence = `${biggest}-${Number.MAX_SAFE_INTEGER}`;
         if (params.after) {
-            delete params.after;
+          delete params.after;
         }
+      }
     }
 
-    let seriesArray = [];
+    let seriesArray = Object.keys(bpMap)
+      .sort((left, right) => left.localeCompare(right))
+      .map((bp) => ({
+        name: bp,
+        data: bpMap[bp].sort((left, right) => left[0] - right[0]),
+      }));
 
-    for (const bp in bpMap) {
-        seriesArray.push({
-            name: bp,
-            data: bpMap[bp],
-        });
-    }
+    commit("validators/setBenchmarks", seriesArray, { root: true });
 
-    commit('validators/setBenchmarks', seriesArray, { root: true });
+    return {
+      benchmarks: seriesArray,
+      latestTimestamp: getActionTimestamp(latestAction),
+    };
+  } catch (error) {
+    commit("validators/setBenchmarks", [], { root: true });
+    throw error;
+  }
 }

--- a/src/store/validators/actions.js
+++ b/src/store/validators/actions.js
@@ -61,11 +61,16 @@ export async function loadBenchmarks({ commit }, { days }) {
 
     const latestAction = latestBenchmarks.data.actions[0];
 
-    if (!latestAction) {
+    const latestTs = latestAction ? moment(getActionTimestamp(latestAction)) : null;
+    const isStale = latestTs && moment().diff(latestTs, "days") > 7;
+
+    if (!latestAction || isStale) {
+      // Hyperion data is stale (last eosmechanics action >7 days old).
+      // Return empty chart rather than misleading stale data.
       commit("validators/setBenchmarks", [], { root: true });
       return {
         benchmarks: [],
-        latestTimestamp: null,
+        latestTimestamp: latestTs ? latestTs.toISOString() : null,
       };
     }
 

--- a/src/store/validators/actions.js
+++ b/src/store/validators/actions.js
@@ -22,8 +22,35 @@ function getActionPoint(action) {
   };
 }
 
+// Use our own benchmark API as primary (Hyperion eosmechanics data is stale)
+// Falls back to Hyperion if the benchmark API is unavailable
 export async function loadBenchmarks({ commit }, { days }) {
   try {
+    // Try our live benchmark API first
+    try {
+      const benchmarkResp = await fetch(process.env.BENCHMARK_API);
+      const latestBenchmark = await benchmarkResp.json();
+      if (latestBenchmark && latestBenchmark.gas_used) {
+        const ts = latestBenchmark.timestamp
+          ? moment(latestBenchmark.timestamp).valueOf()
+          : Date.now();
+        // Build a single-series Highcharts-compatible array from the live benchmark
+        const seriesData = [[ts, latestBenchmark.gas_used]];
+        const seriesArray = [{
+          name: "EVM CPU (gas)",
+          data: seriesData,
+        }];
+        commit("validators/setBenchmarks", seriesArray, { root: true });
+        return {
+          benchmarks: seriesArray,
+          latestTimestamp: latestBenchmark.timestamp,
+        };
+      }
+    } catch (benchErr) {
+      console.warn("Benchmark API failed, falling back to Hyperion:", benchErr);
+    }
+
+    // Fall back to Hyperion (original behavior)
     const latestBenchmarks = await this.$hyperion.get(HYPERION_ACTIONS_PATH, {
       params: {
         filter: BENCHMARK_FILTER,


### PR DESCRIPTION
## Summary

Three fixes:

### 1. Live validators API (replaces S3 bucket) ⭐
The  S3 bucket stopped being updated (last upload Nov 2024). Replaced with a live **Netlify Function** that fetches producer data directly from the Telos chain + bp.json on every request.

**Changes in :**
- Replaced S3 bucket URL with live API: 
- Removed S3 XML listing/parsing logic — no more broken "lastUpdated" from stale bucket files
-  now reflects current fetch time

**The Netlify Function ():**
- Fetches producers from 
- Fetches  for each producer in parallel
- Merges chain data + bp.json data into the same schema as the old S3 bucket
- Sorts by total_votes descending
- Returns 100 producers live

### 2.  — loadBenchmarks pagination rewrite
- Anchors display window to latest available benchmark (not current time)
- Implements proper  range-based pagination
- Adds try/catch error handling
- Removes debug console.log statements

### 3.  +  — network labels
Hardcoded "Mainnet" labels now use `process.env.NETWORK_ENV` to show correct network.

## Validation
- Live API tested: returns 100 producers with full chain + bp.json data
- Manual test on staging deploy recommended